### PR TITLE
prepRasterToMatch doesn't use the `templateRas` crs b/c useSAcrs is forced to TRUE --> this seems wrong

### DIFF
--- a/R/prepInputObjects.R
+++ b/R/prepInputObjects.R
@@ -714,7 +714,7 @@ prepRasterToMatch <- function(studyArea, studyAreaLarge,
         templateRas <- Cache(postProcessTerra,
                              templateRas,
                              studyArea = studyAreaLarge,
-                             useSAcrs = TRUE,
+                             useSAcrs = FALSE,
                              overwrite = TRUE,
                              userTags = c("postRTMtemplate"))
         templateRas <- fixErrors(templateRas)


### PR DESCRIPTION
prepRasterToMatch has rasterToMatch and templateRas args. The templateRas argument will be reprojected to studyAreaLarge, creating data artifacts. This should never "willy-nilly" be done. We should always convert vector GIS datasets to the crs of the raster dataset. 

With this default behaviour as it was before, it was impossible for `borealDataPrep` to run "with defaults" because the `rawBIomassMap` would be different than all other raster layers.

This PR asks that we change this so that all rasters are same.  