### PR TITLE
filename2 ==> writeTo

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,8 +8,8 @@ Description: Utilities for 'LandR' suite of landscape simulation models.
 URL: 
     https://landr.predictiveecology.org,
     https://github.com/PredictiveEcology/LandR
-Date: 2024-07-04
-Version: 1.1.5.9005
+Date: 2024-07-10
+Version: 1.1.5.9006
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/R/prepSpeciesLayers.R
+++ b/R/prepSpeciesLayers.R
@@ -286,7 +286,7 @@ prepSpeciesLayers_CASFRI <- function(destinationPath, outputPath,
                      rasterToMatch = rasterToMatch,
                      method = "bilinear", ## ignore warning re: ngb (#5)
                      datatype = "INT4U",
-                     filename2 = NULL,
+                     writeTo = NULL,
                      overwrite = TRUE,
                      userTags =  c("CASFRIRas", "stable"))
 
@@ -335,7 +335,7 @@ prepSpeciesLayers_Pickell <- function(destinationPath, outputPath,
                          rasterToMatch = rasterToMatch,
                          method = "bilinear", ## ignore warning re: ngb (#5)
                          datatype = "INT2U",
-                         filename2 = NULL,
+                         writeTo = NULL,
                          overwrite = TRUE,
                          userTags = c("speciesLayers", "KNN", "Pickell", "stable"))
 
@@ -371,7 +371,7 @@ prepSpeciesLayers_ForestInventory <- function(destinationPath, outputPath,
 
   lr <- lapply(CClayerNamesFiles, prepInputs, studyArea = studyArea, rasterToMatch = rasterToMatch,
                url = url, alsoExtract = "similar", method = "ngb",
-               destinationPath = destinationPath, filename2 = NULL)
+               destinationPath = destinationPath, writeTo = NULL)
   rs <- raster::stack(lr)
   names(rs) <- CClayerNames
 
@@ -424,7 +424,7 @@ prepSpeciesLayers_MBFRI <- function(destinationPath, outputPath,
 
   lr <- lapply(CClayerNamesFiles, prepInputs, studyArea = studyArea, rasterToMatch = rasterToMatch,
                url = url, alsoExtract = "similar", method = "ngb",
-               destinationPath = destinationPath, filename2 = NULL)
+               destinationPath = destinationPath, writeTo = NULL)
   rs <- stack(lr)
   names(rs) <- CClayerNames2
 
@@ -506,7 +506,7 @@ prepSpeciesLayers_ONFRI <- function(destinationPath, outputPath,
 
   sppLayers <- rast(lapply(FRIlayerNamesFiles, function(f) {
     prepInputs(url = url, studyArea = studyArea, rasterToMatch = rasterToMatch,
-               destinationPath = destinationPath, targetFile = f, filename2 = NULL,
+               destinationPath = destinationPath, targetFile = f, writeTo = NULL,
                alsoExtract = NA, method = "near")
   }))
   names(sppLayers) <- FRIlayerNames

--- a/man/defineFlammable.Rd
+++ b/man/defineFlammable.Rd
@@ -9,7 +9,8 @@ defineFlammable(
   nonFlammClasses = c(0L, 25L, 30L, 33L, 36L, 37L, 38L, 39L),
   mask = NULL,
   to = NULL,
-  filename2 = NULL
+  writeTo = NULL,
+  ...
 )
 }
 \arguments{
@@ -23,7 +24,9 @@ defineFlammable(
 \item{to}{Passed to \code{postProcessTo(..., to = to)} and to the \code{mask} arg here, if
 \code{mask} is not supplied.}
 
-\item{filename2}{See \code{\link[reproducible:postProcess]{reproducible::postProcess()}}. Default \code{NULL}.}
+\item{writeTo}{See \code{\link[reproducible:postProcess]{reproducible::postProcess()}}. Default \code{NULL}.}
+
+\item{...}{additional args (not used)}
 }
 \description{
 Define flammability map

--- a/man/prepInputsLCC.Rd
+++ b/man/prepInputsLCC.Rd
@@ -8,7 +8,7 @@ prepInputsLCC(
   year = 2010,
   destinationPath = asPath("."),
   method = c("ngb", "near"),
-  filename2 = NULL,
+  writeTo = NULL,
   ...
 )
 }
@@ -26,7 +26,7 @@ search for the file before attempting to download. Default for that option is
 \item{method}{passed to \link[terra:intersect]{terra::intersect} or \link[raster:intersect]{raster::intersect},
 and \link[reproducible:prepInputs]{reproducible::prepInputs}}
 
-\item{filename2}{passed to \link[reproducible:prepInputs]{reproducible::prepInputs}}
+\item{writeTo}{passed to \link[reproducible:prepInputs]{reproducible::prepInputs}}
 
 \item{...}{Arguments passed to \code{terra::mask} (for \code{maskTo}), \code{terra::project} (for \code{projectTo})
 or \code{terra::writeRaster} (for \code{writeTo}) and not used for \code{cropTo}, as well \code{postProcess}'s

--- a/man/prepInputsStandAgeMap.Rd
+++ b/man/prepInputsStandAgeMap.Rd
@@ -12,7 +12,7 @@ prepInputsStandAgeMap(
   method = "bilinear",
   datatype = "INT2U",
   destinationPath = NULL,
-  filename2 = NULL,
+  writeTo = NULL,
   firePerimeters = NULL,
   fireURL = paste0("https://cwfis.cfs.nrcan.gc.ca/downloads/nfdb/",
     "fire_poly/current_version/NFDB_poly.zip"),
@@ -37,7 +37,7 @@ prepInputsStandAgeMap(
 
 \item{destinationPath}{path to data directory where objects will be downloaded or saved to}
 
-\item{filename2}{passed to \code{\link[reproducible:prepInputs]{reproducible::prepInputs()}} of stand age map}
+\item{writeTo}{passed to \code{\link[reproducible:prepInputs]{reproducible::prepInputs()}} of stand age map}
 
 \item{firePerimeters}{fire raster layer fire year values.}
 

--- a/man/prepRawBiomassMap.Rd
+++ b/man/prepRawBiomassMap.Rd
@@ -19,7 +19,7 @@ the NRCan National Forest Inventory}
 \item{\code{useSAcrs} and \code{projectTo}: \code{FALSE} and \code{NA}}
 \item{\code{method}: \code{"bilinear"}}
 \item{\code{datatype}: \code{"INT2U"}}
-\item{\code{filename2}: \code{suffix("rawBiomassMap.tif", paste0("_", studyAreaName))}}
+\item{\code{writeTo}: \code{suffix("rawBiomassMap.tif", paste0("_", studyAreaName))}}
 \item{\code{overwrite}: \code{TRUE}}
 \item{\code{userTags}: \code{c(cacheTags, "rawBiomassMap")}}
 \item{\code{omitArgs}: \code{c("destinationPath", "targetFile", "userTags", "stable")}}
@@ -29,7 +29,6 @@ the NRCan National Forest Inventory}
 a \code{rawBiomassMap} raster
 }
 \description{
-Create the \code{rawBiomassMap} raster containing biomass estimates for
-\code{pixelCohortData}.
+Create the \code{rawBiomassMap} raster containing biomass estimates for \code{pixelCohortData}.
 Wrapper on \code{\link[reproducible:prepInputs]{reproducible::prepInputs()}} that will rasterize fire polygons.
 }


### PR DESCRIPTION
latest `reproducible` is strict about enforcing use of `writeTo` instead of `filename2`. this PR makes this change, and tries to ensure that if user was passing `filename2` that it gets converted to `writeTo` where possible