### PR TITLE
prepStandAgeMap tweaks

### DIFF
--- a/R/prepInputObjects.R
+++ b/R/prepInputObjects.R
@@ -505,7 +505,7 @@ prepInputsStandAgeMap <- function(
       datatype = datatype,
       to = rasterToMatch,
       ...
-    )
+    ) |> Cache(.functionName = "prepInputs_ageMapFromSCANFI")
 
     if (dataYear != "2020") {
       #use NTEMS to identify disturbances (harvest and fire) that occurred between dataYear and 2020
@@ -526,13 +526,13 @@ prepInputsStandAgeMap <- function(
         destinationPath = destinationPath,
         to = standAgeMap,
         method = "near"
-      )
+      )  |> Cache(.functionName = "prepInputs_CA_ForestFire1985to2020")
       harvest_NTEMS <- prepInputs(
         url = "https://opendata.nfis.org/downloads/forest_change/CA_Forest_Harvest_1985-2020.zip",
         destinationPath = destinationPath,
         to = standAgeMap,
         method = "near"
-      )
+      ) |> Cache(.functionName = "prepInputs_CA_Harvest1985to2020")
       NAflag(fire_NTEMS) <- 0
       NAflag(harvest_NTEMS) <- 0
 

--- a/R/prepInputObjects.R
+++ b/R/prepInputObjects.R
@@ -625,11 +625,13 @@ prepInputsStandAgeMap <- function(
   }
 
   if (is(standAgeMap, "SpatRaster")) {
-    vals <- as.vector(standAgeMap[])
+    standAgeMap <- as.int(standAgeMap + 0.5)
+    # vals <- as.vector(standAgeMap[])
   } else {
     vals <- standAgeMap[]
+    standAgeMap[] <- asInteger(vals)
   }
-  standAgeMap[] <- asInteger(vals)
+  
 
   if (getFires) {
     if (isFALSE(is.null(rasterToMatch))) {


### PR DESCRIPTION
- Function is now run >1 time (e.g., 2000, 2010, 2020); 
- without Cache, it runs slow/long prepInputs 3 times for 3 objects; 
- add Cache()
- also use `as.int(x + 0.5)` because it keeps out of RAM