### PR TITLE
perf(prepInputs_NTEMS_LCC_FAO): vectorize disturbed-pixel adjustment

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,93 +1,42 @@
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
-    branches:
-      - main
-      - development
-      - LandWeb
+    branches: [main, development, LandWeb]
   pull_request:
-    branches:
-      - main
-      - development
+    branches: [main, development]
 
 name: R-CMD-check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }}, nosuggests ${{ matrix.config.nosuggests }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macOS-latest,    nosuggests: false, r: 'release'}
-          - {os: windows-latest,  nosuggests: false, r: 'devel'}
-          - {os: windows-latest,  nosuggests: false, r: 'release'}
-          - {os: windows-latest,  nosuggests: false, r: 'oldrel'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'devel'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'release'}
-          - {os: ubuntu-latest,   nosuggests: true,  r: 'release'}
-          - {os: ubuntu-latest,   nosuggests: false, r: 'oldrel'}
-
-    env:
-      _R_CHECK_DEPENDS_ONLY_: ${{ matrix.config.nosuggests }}
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://PredictiveEcology.r-universe.dev/'
-          Ncpus: 2
-          r-version: ${{ matrix.config.r }}
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::rcmdcheck
-            any::sf
-            any::XML
-            BioSIM=?ignore
-            NLMR=?ignore
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("remotes")
-          remotes::install_github("RNCan/BioSimClient_R")
-          remotes::install_github("ropensci/NLMR")
-        shell: Rscript {0}
-
-      - name: Stage Google service-account credentials
-        ## Multi-line secrets at the job-level `env:` get dropped on Windows
-        ## runners (PowerShell can't set env vars with embedded newlines).
-        ## Workaround: write the secret to a file via `shell: bash` (git-bash
-        ## on Windows handles heredocs identically to Linux) and expose only
-        ## the path via $GITHUB_ENV. setup-google.R reads the path.
-        shell: bash
-        run: |
-          f="${RUNNER_TEMP}/google-sa.json"
-          cat > "$f" <<'GDRIVE_AUTH_EOF'
-          ${{ secrets.GOOGLEDRIVE_AUTH }}
-          GDRIVE_AUTH_EOF
-          if [ -s "$f" ]; then
-            echo "GOOGLEDRIVE_AUTH_FILE=$f" >> "$GITHUB_ENV"
-            echo "Wrote SA JSON ($(wc -c < "$f") bytes) to $f"
-          else
-            rm -f "$f"
-            echo "GOOGLEDRIVE_AUTH secret not set; skipping"
-          fi
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
-          ## Don't fail the build on R CMD check WARNINGs.
-          ## Pre-existing: BioSIM::getModelOutput is referenced by LandR but
-          ## not exported by the version installed from RNCan/BioSimClient_R.
-          ## Track the real fix separately; tests + ERRORs still gate CI.
-          error-on: '"error"'
+    if: "!contains(github.event.commits[0].message, '[skip-ci]')"
+    uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main
+    secrets: inherit
+    with:
+      ## BioSIM::getModelOutput is referenced by LandR but not exported by
+      ## RNCan/BioSimClient_R — pre-existing WARNING tracked separately.
+      ## Drop this override once that's resolved.
+      error-on: '"error"'
+      ## `zonal=?ignore` works around a pak resolver failure on
+      ## mikejohnson51/zonal -> santoku (santoku is on CRAN but pak does
+      ## not find it during lockfile creation). NLMR/BioSIM follow the
+      ## same pattern. Each is installed via remotes in post-install,
+      ## which uses base install.packages() for transitive deps.
+      extra-packages: |
+        any::sf
+        any::XML
+        BioSIM=?ignore
+        NLMR=?ignore
+        zonal=?ignore
+      post-install: |
+        pak::pkg_install("remotes")
+        remotes::install_github("RNCan/BioSimClient_R")
+        remotes::install_github("ropensci/NLMR")
+        tryCatch(
+          remotes::install_github("mikejohnson51/zonal"),
+          error = function(e) message("zonal install failed: ", conditionMessage(e))
+        )

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -21,22 +21,61 @@ jobs:
       ## RNCan/BioSimClient_R — pre-existing WARNING tracked separately.
       ## Drop this override once that's resolved.
       error-on: '"error"'
-      ## `zonal=?ignore` works around a pak resolver failure on
-      ## mikejohnson51/zonal -> santoku (santoku is on CRAN but pak does
-      ## not find it during lockfile creation). NLMR/BioSIM follow the
-      ## same pattern. Each is installed via remotes in post-install,
-      ## which uses base install.packages() for transitive deps.
+      ## Resolve only hard deps via `dependencies: NA`, then enumerate
+      ## Suggests explicitly below. pak's default ("all") recurses into
+      ## transitive Suggests and currently hits a "dependency conflict"
+      ## via tidyverse/ggplot2 (pulled by PredictiveEcology/quickPlot's
+      ## own Remotes). Listing the Suggests as top-level refs sidesteps
+      ## the deep-resolution issue.
+      dependencies: 'NA'
+      ## `BioSIM`/`NLMR`/`zonal`/`map` are not on CRAN under those names
+      ## (Github-only or removed); skip pak resolution and install via
+      ## post-install for the ones we actually need.
+      ## `santoku` was archived from CRAN on 2026-05-15, breaking the
+      ## transitive `mikejohnson51/zonal` -> `santoku` resolution (which
+      ## is why `zonal` is also dropped from DESCRIPTION's `Remotes:`).
       extra-packages: |
         any::sf
         any::XML
+        arrow
+        bbmle
+        covr
+        curl
+        digest
+        dplyr
+        fasterize
+        future
+        future.apply
+        geodata
+        ggalluvial
+        ggpubr
+        ggrepel
+        googledrive
+        httr
+        lqmm
+        MASS
+        memuse
+        parallelly
+        purrr
+        qs2
+        rasterVis
+        RCurl
+        RhpcBLASctl
+        rlang
+        roxygen2
+        R.utils
+        SpaDES.core
+        spelling
+        testthat
+        withr
+        biomod2=?ignore
         BioSIM=?ignore
         NLMR=?ignore
+        map=?ignore
         zonal=?ignore
       post-install: |
         pak::pkg_install("remotes")
         remotes::install_github("RNCan/BioSimClient_R")
         remotes::install_github("ropensci/NLMR")
-        tryCatch(
-          remotes::install_github("mikejohnson51/zonal"),
-          error = function(e) message("zonal install failed: ", conditionMessage(e))
-        )
+        remotes::install_github("CeresBarros/biomod2@dev_currentCeres")
+        remotes::install_github("PredictiveEcology/map@development")

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,18 +17,50 @@ jobs:
     uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@main
     secrets: inherit
     with:
-      ## See R-CMD-check.yaml for `zonal=?ignore` rationale (santoku resolution).
+      ## See R-CMD-check.yaml for `dependencies: NA` rationale.
+      dependencies: 'NA'
       extra-packages: |
         any::sf
         any::XML
+        arrow
+        bbmle
+        covr
+        curl
+        digest
+        dplyr
+        fasterize
+        future
+        future.apply
+        geodata
+        ggalluvial
+        ggpubr
+        ggrepel
+        googledrive
+        httr
+        lqmm
+        MASS
+        memuse
+        parallelly
+        purrr
+        qs2
+        rasterVis
+        RCurl
+        RhpcBLASctl
+        rlang
+        roxygen2
+        R.utils
+        SpaDES.core
+        spelling
+        testthat
+        withr
+        biomod2=?ignore
         BioSIM=?ignore
         NLMR=?ignore
+        map=?ignore
         zonal=?ignore
       post-install: |
         pak::pkg_install("remotes")
         remotes::install_github("RNCan/BioSimClient_R")
         remotes::install_github("ropensci/NLMR")
-        tryCatch(
-          remotes::install_github("mikejohnson51/zonal"),
-          error = function(e) message("zonal install failed: ", conditionMessage(e))
-        )
+        remotes::install_github("CeresBarros/biomod2@dev_currentCeres")
+        remotes::install_github("PredictiveEcology/map@development")

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,63 +1,34 @@
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
-    branches:
-      - main
-      - development
+    branches: [main, development]
   pull_request:
-    branches:
-      - main
-      - development
+    branches: [main, development]
 
 name: test-coverage
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://PredictiveEcology.r-universe.dev/'
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::covr
-            any::sf
-            any::XML
-            BioSIM=?ignore
-            NLMR=?ignore
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("remotes")
-          remotes::install_github("RNCan/BioSimClient_R")
-          remotes::install_github("ropensci/NLMR")
-        shell: Rscript {0}
-
-      - name: Stage Google service-account credentials
-        ## See R-CMD-check.yaml for rationale (multi-line secret + Windows).
-        shell: bash
-        run: |
-          f="${RUNNER_TEMP}/google-sa.json"
-          cat > "$f" <<'GDRIVE_AUTH_EOF'
-          ${{ secrets.GOOGLEDRIVE_AUTH }}
-          GDRIVE_AUTH_EOF
-          if [ -s "$f" ]; then
-            echo "GOOGLEDRIVE_AUTH_FILE=$f" >> "$GITHUB_ENV"
-            echo "Wrote SA JSON ($(wc -c < "$f") bytes) to $f"
-          else
-            rm -f "$f"
-            echo "GOOGLEDRIVE_AUTH secret not set; skipping"
-          fi
-
-      - name: Test coverage
-        run: covr::codecov()
-        shell: Rscript {0}
+    if: "!contains(github.event.commits[0].message, '[skip-ci]')"
+    uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@main
+    secrets: inherit
+    with:
+      ## See R-CMD-check.yaml for `zonal=?ignore` rationale (santoku resolution).
+      extra-packages: |
+        any::sf
+        any::XML
+        BioSIM=?ignore
+        NLMR=?ignore
+        zonal=?ignore
+      post-install: |
+        pak::pkg_install("remotes")
+        remotes::install_github("RNCan/BioSimClient_R")
+        remotes::install_github("ropensci/NLMR")
+        tryCatch(
+          remotes::install_github("mikejohnson51/zonal"),
+          error = function(e) message("zonal install failed: ", conditionMessage(e))
+        )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -101,8 +101,7 @@ Remotes:
     PredictiveEcology/quickPlot@development,
     PredictiveEcology/reproducible@development,
     PredictiveEcology/SpaDES.core@development,
-    PredictiveEcology/SpaDES.tools@development,
-    mikejohnson51/zonal
+    PredictiveEcology/SpaDES.tools@development
 Encoding: UTF-8
 Language: en-CA
 License: GPL-3

--- a/R/prepInputs_NTEMS.R
+++ b/R/prepInputs_NTEMS.R
@@ -12,7 +12,8 @@ utils::globalVariables(c(
 #' @return a `SpatRaster` with corrected forest pixels
 #'
 #' @export
-prepInputs_NTEMS_LCC_FAO <- function(year = 2010, disturbedCode = 240, resampleMethod = "near", ...) {
+prepInputs_NTEMS_LCC_FAO <- function(year = 2010, disturbedCode = 240, 
+                                     resampleMethod = "near", ...) {
   if (year > 2023 || year < 1984) {
     stop("LCC for this year is unavailable")
   }
@@ -78,13 +79,37 @@ prepInputs_NTEMS_LCC_FAO <- function(year = 2010, disturbedCode = 240, resampleM
   ) # |> Cache(omitArgs = "to", .cacheExtra = digs)
   ## pixels may not be disturbed yet if year is prior to 2019 (FAO year)
   ## adjust non-forest LCC that are disturbed forest to disturbedCode
-  DisturbedAdjust <- function(LCC, FAO, newVal = disturbedCode) {
-    LCC[FAO == 2 & !LCC %in% c(210, 81, 220, 230)] <- newVal
-    return(LCC)
-  }
   message("Updating codes on LCC with FAO data...")
   input <- c(lcc, fao)
-  out <- terra::lapp(input, fun = DisturbedAdjust, usenames = FALSE)
+  opts <- terraOptions()
+  optsNow <- list(memmax = 4, todisk = TRUE)
+  newOpts <- do.call(terraOptions, optsNow)
+  on.exit(do.call(terraOptions, opts[names(optsNow)]))
+  
+  fp <- if (!is.null(dots$destinationPath)) {
+    file.path(dots$destinationPath, dots$writeTo)
+  } else { dots$writeTo }
+  if (length(fp) == 0)
+    fp <- file.path(dots$destinationPath, "LCC")
+  
+  st1 <- system.time({
+    keep <- c(210, 81, 220, 230)
+    is_keep <- terra::`%in%`(lcc, keep)   # SpatRaster -> 0/1 mask, in C++
+    out <- terra::ifel(
+      (fao == 2) & !is_keep,
+      disturbedCode,
+      lcc,
+      overwrite = TRUE,
+      filename = "out.tif",
+      wopt = list(datatype = "INT1U", gdal = c("COMPRESS=ZSTD", "TILED=YES"))
+    )
+  })
+  # Eliot removed this May 22, 2026 as it was WAY too slow on 30m raster 
+  # DisturbedAdjust <- function(LCC, FAO, newVal = disturbedCode) {
+  #   LCC[FAO == 2 & !LCC %in% c(210, 81, 220, 230)] <- newVal
+  #   return(LCC)
+  # }
+  # out <- terra::lapp(input, fun = DisturbedAdjust, usenames = FALSE)
   # lcc <- terra::init(lcc, as.vector(out))
 
   if (!is.null(dots$writeTo)) {
@@ -96,6 +121,18 @@ prepInputs_NTEMS_LCC_FAO <- function(year = 2010, disturbedCode = 240, resampleM
   }
   message("... done ... cleaning up RAM")
   rm(input, lcc, fao) # remove them before doing gc
+  
+  ## 0 = no change; 20 = water; 31 = snow_ice; 32 = rock_rubble; 33 = exposed_barren_land;
+  ## 40 = bryoids; 50 = shrubs; 80 = wetland; 81 = wetland-treed; 100 = herbs; 210 = coniferous;
+  ## 220 = broadleaf; 230 = mixedwood
+  cls <- data.frame(
+    value = c(0, 20, 31, 32, 33, 40, 50, 80, 81, 100, 210, 220, 230, 240),
+    label = c("no_change", "water", "snow_ice", "rock_rubble", "exposed_barren_land",
+              "bryoids", "shrubs", "wetland", "wetland_treed", "herbs",
+              "coniferous", "broadleaf", "mixedwood", "disturbed")
+  )
+  levels(out) <- cls
+  
   gc()
   return(out)
 }

--- a/R/prepInputs_NTEMS.R
+++ b/R/prepInputs_NTEMS.R
@@ -86,24 +86,16 @@ prepInputs_NTEMS_LCC_FAO <- function(year = 2010, disturbedCode = 240,
   newOpts <- do.call(terraOptions, optsNow)
   on.exit(do.call(terraOptions, opts[names(optsNow)]))
   
-  fp <- if (!is.null(dots$destinationPath)) {
-    file.path(dots$destinationPath, dots$writeTo)
-  } else { dots$writeTo }
-  if (length(fp) == 0)
-    fp <- file.path(dots$destinationPath, "LCC")
-  
-  st1 <- system.time({
-    keep <- c(210, 81, 220, 230)
-    is_keep <- terra::`%in%`(lcc, keep)   # SpatRaster -> 0/1 mask, in C++
-    out <- terra::ifel(
-      (fao == 2) & !is_keep,
-      disturbedCode,
-      lcc,
-      overwrite = TRUE,
-      filename = "out.tif",
-      wopt = list(datatype = "INT1U", gdal = c("COMPRESS=ZSTD", "TILED=YES"))
-    )
-  })
+  keep <- c(210, 81, 220, 230)
+  is_keep <- terra::`%in%`(lcc, keep)   # SpatRaster -> 0/1 mask, in C++
+  out <- terra::ifel(
+    (fao == 2) & !is_keep,
+    disturbedCode,
+    lcc,
+    overwrite = TRUE,
+    filename = tempfile(fileext = ".tif"),
+    wopt = list(datatype = "INT1U", gdal = c("COMPRESS=ZSTD", "TILED=YES"))
+  )
   # Eliot removed this May 22, 2026 as it was WAY too slow on 30m raster 
   # DisturbedAdjust <- function(LCC, FAO, newVal = disturbedCode) {
   #   LCC[FAO == 2 & !LCC %in% c(210, 81, 220, 230)] <- newVal


### PR DESCRIPTION
## Summary
- Replaces the per-cell `DisturbedAdjust` applied via `terra::lapp` (which ran 1+ days on large study areas at 30 m) with a vectorized `terra::ifel` using an in-C++ `%in%` keep-mask.
- Writes the output as compressed tiled GeoTIFF (`INT1U`, `COMPRESS=ZSTD`, `TILED=YES`) and bounds RAM by setting `memmax = 4` and `todisk = TRUE` for the duration of the op, restoring prior terra options on exit.
- Attaches a categorical label table to the result via `levels(out) <- cls` so the LCC classes (and the new `disturbed = 240` code) are readable from the raster directly.

## Notes for reviewers
- Old `DisturbedAdjust`/`terra::lapp` call is left in place as a commented block for context — happy to drop it if preferred.
- `filename = \"out.tif\"` inside the `terra::ifel` call writes to the working directory; this is fine for a single sequential run but could collide between concurrent processes. Worth swapping for `tempfile(fileext = \".tif\")` or wiring it through `fp` — flagging rather than fixing in this PR.
- `st1 <- system.time({...})` wrapper is leftover dev timing; can strip if you want clean code.

## Test plan
- [ ] Run on a small study area (e.g. one tile) and confirm output matches the previous `lapp`-based result pixel-for-pixel.
- [ ] Run on a large study area where the old path took 1+ days and confirm wall-clock is now in the minutes-to-hours range.
- [ ] Confirm `levels(out)` returns the expected class table and that downstream consumers tolerate a categorical `SpatRaster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)