### PR TITLE
Get SCANFI species layers without Google authentication

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -89,6 +89,16 @@
   often as the previous implementation, broadleaf **0.58×** and mixedwood **0.28×**, moving
   roughly one in fourteen unwanted pixels out of forest altogether. `"nearestWeighted"`
   gives the same determinism without that bias.
+* `loadSCANFISpeciesLayers()` now lists the SCANFI species-layer folder via
+  `reproducible::listGoogleDriveFolder()` instead of `googledrive::drive_ls()`.
+  When a directory-remap manifest is set (`options(reproducible.urlRemap = ...)`,
+  e.g. one built with `buckethost::makeMirrorManifest(directories = TRUE)`), the
+  SCANFI files are fetched from a public mirror with **no Google
+  authentication** — the immediate use case is training/workshops, where
+  participants can pull SCANFI layers without a Google account or `drive_auth()`.
+  Behaviour is unchanged when no manifest is set: it falls back to `drive_ls()`
+  and authenticates as before. (Requires the companion `reproducible` change that
+  adds `listGoogleDriveFolder()` and directory remaps.)
 * `LANDISDisp()` spiral seed dispersal loop ported to C++ via `Rcpp`
   (~3.5–5.7× faster end-to-end depending on input size; ~5× on landscape-scale
   fixtures of 9 M cells). Memory use also drops dramatically: the

--- a/R/maps.R
+++ b/R/maps.R
@@ -1548,14 +1548,20 @@ loadSCANFISpeciesLayers <- function(
     }
   }
 
-  driveFiles <- as.data.table(googledrive::with_drive_quiet(googledrive::drive_ls(url)))
+  ## List the folder via reproducible's remap-aware helper: when a directory
+  ## remap manifest is set (reproducible.urlRemap), the files are enumerated from
+  ## a public mirror with NO Google authentication; otherwise it falls back to
+  ## googledrive::drive_ls(). The returned `url` column is the mirror URL when
+  ## remapped, else the Drive file URL -- used directly below instead of building
+  ## one from the Drive id (the mirror listing carries no Drive id).
+  driveFiles <- reproducible::listGoogleDriveFolder(url)
   driveFiles <- driveFiles[grepl("SCANFI_sps", name)] ## selecting just species layers
   driveFiles <- driveFiles[grep("tif.", name, invert = TRUE)] ## removing .ovr and .aux files
   if (dataVersion == "V2") {
     driveFiles <- driveFiles[grep("prcB_other", name, invert = TRUE)] #Removing generic species layers
     driveFiles <- driveFiles[grep("prcC_other", name, invert = TRUE)]
   }
-  fileURLs <- paste0("https://drive.google.com/file/d/", driveFiles$id)
+  fileURLs <- driveFiles$url
   fileNames <- c(driveFiles$name)
   names(fileURLs) <- fileNames
 


### PR DESCRIPTION
## What

`loadSCANFISpeciesLayers()` now lists the SCANFI species-layer folder via `reproducible::listGoogleDriveFolder()` instead of calling `googledrive::drive_ls()` directly.

When a **directory-remap manifest** is set:

```r
options(reproducible.urlRemap = "arbutus_manifest_SCANFI_v2_clean.csv")
# manifest built with buckethost::makeMirrorManifest(directories = TRUE)
```

the SCANFI files are enumerated from a **public mirror (Arbutus object store) with no Google authentication** — no Google account, no `drive_auth()`. The immediate use case is **training/workshops**, where participants can pull SCANFI layers anonymously.

## Why this is safe / backwards compatible

- **No manifest set** → `listGoogleDriveFolder()` falls back to `googledrive::drive_ls()` and authenticates exactly as before. Identical behaviour.
- The per-file downloads already went through `prepInputs()`, so only the *folder listing* needed changing.
- The listing's `url` column is used directly (mirror URL when remapped, else the Drive file URL) instead of building `https://drive.google.com/file/d/<id>` — because the mirror listing carries no Drive id.

## The change

Two lines in `R/maps.R` (`loadSCANFISpeciesLayers`):

```r
- driveFiles <- as.data.table(googledrive::with_drive_quiet(googledrive::drive_ls(url)))
+ driveFiles <- reproducible::listGoogleDriveFolder(url)
...
- fileURLs <- paste0("https://drive.google.com/file/d/", driveFiles$id)
+ fileURLs <- driveFiles$url
```

## Dependency note

⚠️ Requires the companion **`reproducible`** change that adds `listGoogleDriveFolder()` and directory-remap support (the `type="dir"` manifest column + `byDir`). That must be merged to `reproducible@development` before LandR CI here will pass. Once it lands, the existing `Remotes: PredictiveEcology/reproducible@development` picks it up; a `reproducible (>=` version floor bump in `DESCRIPTION` can follow when reproducible releases.

## Scope

Only the `loadSCANFISpeciesLayers` site (`maps.R:1520`). The other `drive_ls` sites are intentionally left as-is (the kNN twin would also need `shared_drive` passthrough; the `prepSpeciesLayers` sites navigate Drive subfolder structure, not file listings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)