### PR TITLE
Cache stand-age and NTEMS LCC/FAO prepInputs steps

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,6 @@
     "[quarto]": {
         "editor.formatOnSave": true,
         "editor.defaultFormatter": "quarto.quarto"
-    }
+    },
+    "positron.r.useNativePipe": true
 }

--- a/R/prepInputObjects.R
+++ b/R/prepInputObjects.R
@@ -488,6 +488,7 @@ prepInputsStandAgeMap <- function(
     ...
 ) {
 
+  digRTM <- .robustDigest(rasterToMatch)
   dots <- list(...)
   if (is.null(writeTo) && !is.null(dots$filename2)) {
     writeTo <- dots$filename2
@@ -510,7 +511,8 @@ prepInputsStandAgeMap <- function(
         datatype = datatype,
         to = rasterToMatch,
         ...
-      ) |> Cache(.functionName = "prepInputs_ageMapFromSCANFI")
+      ) |> Cache(.functionName = "prepInputs_ageMapFromSCANFI", omitArgs = "to",
+                 .cacheExtra = digRTM)
 
       if (dataYear != "2020") {
         #use NTEMS to identify disturbances (harvest and fire) that occurred between dataYear and 2020
@@ -611,10 +613,12 @@ prepInputsStandAgeMap <- function(
         datatype = datatype,
         method = method,
         fun = ageFun,
-        datatype = datatype,
+        # datatype = datatype,
         to = rasterToMatch,
         ...
-      ) |> Cache(.functionName = "prepInputs_ageMapFromSCANFI")
+      ) |> Cache(.functionName = paste0("prepInputs_ageMapFromSCANFI", "_", dataYear), 
+                 omitArgs = "to",
+                 .cacheExtra = digRTM)
 
     }
   }
@@ -677,15 +681,15 @@ prepInputsStandAgeMap <- function(
 
   if (getFires) {
     if (isFALSE(is.null(rasterToMatch))) {
-      firePerimeters <- Cache(
-        prepInputsFireYear,
+      firePerimeters <- prepInputsFireYear(
         ...,
         url = fireURL,
         fun = fireFun,
         fireField = fireField,
         destinationPath = destinationPath,
         rasterToMatch = rasterToMatch
-      )
+      ) |> Cache(omitArgs = "rasterToMatch",
+                 .cacheExtra = digRTM)
     } else {
       message(
         "No 'rasterToMatch' or 'firePerimeters' supplied; ages will NOT be adjusted using fire data."
@@ -915,20 +919,31 @@ prepInputsFireYear <- function(..., rasterToMatch, fireField = "YEAR", earliestY
   preProcessArgs2$url <- NULL
 
   ## There are at least 2 .shp files now (as of Dec 2, 2025)
-  lots <- Map(shp = shpFiles, function(shp) {
-    preProcessArgs2$targetFile = file.path(preProcessArgs2$destinationPath, shp)
-    shp1 <- terra::vect(preProcessArgs2$targetFile)
-    preProcessArgs2$targetFile <- NULL
-    do.call(postProcess, append(list(x = shp1), preProcessArgs2))
-  })
-
-  allFires <- lots[[1]]
-
-  if (length(lots) > 1) {
-    for (i in 2:length(lots)) {
-      allFires <- rbind(allFires, lots[[i]])
-    }
-  }
+  vv <- Map(shp = shpFiles, function(shp) terra::vect(file.path(preProcessArgs2$destinationPath, shp)))
+  vvv <- terra::vect(vv)
+  # 
+  # unique(vvv$SRC_AGENCY)
+  # sa <- setupStudyArea(list(NAME_1 = c("Alberta", "British Columbia", "Yukon", "Northwest Territories") |> 
+  #                             paste(collapse = "|"))) |> 
+  #   terra::project(terra::crs(rasterToMatch))
+  # unique(vvv$SRC_AGENCY)
+  # 
+  
+  allFires <- do.call(postProcess, append(list(vvv), preProcessArgs2))
+  # lots <- Map(shp = shpFiles, function(shp) {
+  #   preProcessArgs2$targetFile = file.path(preProcessArgs2$destinationPath, shp)
+  #   shp1 <- terra::vect(preProcessArgs2$targetFile)
+  #   preProcessArgs2$targetFile <- NULL
+  #   do.call(postProcess, append(list(x = shp1), preProcessArgs2))
+  # })
+  # 
+  # allFires <- lots[[1]]
+  # 
+  # if (length(lots) > 1) {
+  #   for (i in 2:length(lots)) {
+  #     allFires <- rbind(allFires, lots[[i]])
+  #   }
+  # }
 
   # allFires <- do.call(prepInputs, append(list(fun = fun), preProcessArgs))
 

--- a/R/prepInputs_NTEMS.R
+++ b/R/prepInputs_NTEMS.R
@@ -52,11 +52,10 @@ prepInputs_NTEMS_LCC_FAO <- function(year = 2010, disturbedCode = 240,
   dots$method <- resampleMethod
   dots$writeTo <- newFilename
   # digs <- .robustDigest(dots)
-  lcc <- do.call(prepInputs, dots) # |>
-  #  Cache(.functionName = paste0("prepInputs_NTEMS_LCC_FAO_", year),
-  #        omitArgs = c("targetFile", "writeTo"),
-  #        .cacheExtra = digs)
-
+  lcc <- do.call(prepInputs, dots) |>
+    Cache(.functionName = paste0("prepInputs_NTEMS_LCC_FAO_", year),
+          omitArgs = c("targetFile", "writeTo"))
+  
   dots$writeTo <- writeToFN
 
   ## 2024-12: see #110; don't delete CA_forest_VLCE2 raster even though it's 24GB
@@ -76,26 +75,54 @@ prepInputs_NTEMS_LCC_FAO <- function(year = 2010, disturbedCode = 240,
     url = url,
     method = resampleMethod, destinationPath = dots$destinationPath, to = lcc
     # cropTo = lcc, maskTo = lcc, projectTo = lcc
-  ) # |> Cache(omitArgs = "to", .cacheExtra = digs)
+  ) |> Cache(omitArgs = "to", .cacheExtra = list(cacheId(lcc))) # lcc seems to be prone to false fails; seems like the cacheId is reliable
   ## pixels may not be disturbed yet if year is prior to 2019 (FAO year)
   ## adjust non-forest LCC that are disturbed forest to disturbedCode
   message("Updating codes on LCC with FAO data...")
   input <- c(lcc, fao)
-  opts <- terraOptions()
+  opts <- terraOptions(print = FALSE)
   optsNow <- list(memmax = 4, todisk = TRUE)
-  newOpts <- do.call(terraOptions, optsNow)
-  on.exit(do.call(terraOptions, opts[names(optsNow)]), add = TRUE)
+  newOpts <- do.call(terraOptions, append(optsNow, list(print = FALSE)))
+  on.exit(do.call(terraOptions, append(opts[names(optsNow)], list(print = FALSE))), add = TRUE)
   
-  keep <- c(210, 81, 220, 230)
-  is_keep <- terra::`%in%`(lcc, keep)   # SpatRaster -> 0/1 mask, in C++
-  out <- terra::ifel(
-    (fao == 2) & !is_keep,
-    disturbedCode,
-    lcc,
-    overwrite = TRUE,
-    filename = tempfile(fileext = ".tif"),
-    wopt = list(datatype = "INT1U", gdal = c("COMPRESS=ZSTD", "TILED=YES"))
-  )
+  # These are needed for the digest below
+  keepCodes <- c(210, 81, 220, 230)
+  woptArgs <- list(datatype = "INT1U", gdal = c("COMPRESS=ZSTD", "TILED=YES"))
+  fp <- if (!is.null(dots$writeTo)) {
+    if (!is.null(dots$destinationPath)) {
+      file.path(dots$destinationPath, dots$writeTo)
+    } else { dots$writeTo }
+    # assign it to itself or it stays in memory
+    # out <- writeRaster(out, filename = fp, overwrite = TRUE) #overwrite lcc
+  } else {
+    tempfile(fileext = ".tif")
+  }
+  dig <- .robustDigest(list(lcc = cacheId(lcc), 
+                            keepCodes = keepCodes, disturbedCode = disturbedCode,
+                            woptArgs = woptArgs, fp = fp))
+  out <- { lcc |>
+    terra::`%in%`(keepCodes) |>
+    (\(is_keep) terra::ifel(
+      (fao == 2) & !is_keep,
+      disturbedCode,
+      lcc,
+      overwrite = TRUE,
+      filename = fp,
+      wopt = woptArgs
+    ))() } |>
+    Cache(.functionName = "convertCodes", omitArgs = TRUE, 
+          .cacheExtra = dig)
+  
+  # keep <- c(210, 81, 220, 230)
+  # is_keep <- terra::`%in%`(lcc, keep)   # SpatRaster -> 0/1 mask, in C++
+  # out <- terra::ifel(
+  #   (fao == 2) & !is_keep,
+  #   disturbedCode,
+  #   lcc,
+  #   overwrite = TRUE,
+  #   filename = tempfile(fileext = ".tif"),
+  #   wopt = list(datatype = "INT1U", gdal = c("COMPRESS=ZSTD", "TILED=YES"))
+  # )
   # Eliot removed this May 22, 2026 as it was WAY too slow on 30m raster 
   # DisturbedAdjust <- function(LCC, FAO, newVal = disturbedCode) {
   #   LCC[FAO == 2 & !LCC %in% c(210, 81, 220, 230)] <- newVal
@@ -104,13 +131,7 @@ prepInputs_NTEMS_LCC_FAO <- function(year = 2010, disturbedCode = 240,
   # out <- terra::lapp(input, fun = DisturbedAdjust, usenames = FALSE)
   # lcc <- terra::init(lcc, as.vector(out))
 
-  if (!is.null(dots$writeTo)) {
-    fp <- if (!is.null(dots$destinationPath)) {
-      file.path(dots$destinationPath, dots$writeTo)
-    } else { dots$writeTo }
-    #assign it to itself or it stays in memory
-    out <- writeRaster(out, filename = fp, overwrite = TRUE) #overwrite lcc
-  }
+  
   message("... done ... cleaning up RAM")
   rm(input, lcc, fao) # remove them before doing gc
   


### PR DESCRIPTION
## Summary
Wraps several expensive `prepInputs` steps in `Cache()` to avoid recomputation:

- **`prepInputsStandAgeMap`** (`R/prepInputObjects.R`): cache the SCANFI age-map and fire-perimeter steps, keyed on a `.robustDigest(rasterToMatch)` with the volatile `to`/`rasterToMatch` args omitted. Fire perimeters are now built by `terra::vect()`-ing the multiple shapefiles into one collection and a single `postProcess`, replacing the per-file `Map` + `rbind` loop.
- **`prepInputs_NTEMS_LCC_FAO`** (`R/prepInputs_NTEMS.R`): cache the LCC fetch and the FAO-disturbance code-conversion (`convertCodes`), keyed on `cacheId(lcc)` rather than digesting the `SpatRaster` directly — the raster digest was prone to false cache misses. Silences `terraOptions` printing.

## Notes
- Several superseded blocks are left commented-out (WIP context); flag if you'd like them removed before merge.
- Includes a one-line `.vscode/settings.json` change (`positron.r.useNativePipe`) — drop if unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)