### PR TITLE
Run robust R-CMD-check matrix on main (fix PRs-to-main not triggering checks)

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,78 +1,81 @@
+# Thin caller — shared logic lives in PredictiveEcology/actions (reusable workflow).
 on:
   push:
-    branches:
-      - master
-      - development
-      - LandWeb
+    branches: [main, development, LandWeb]
   pull_request:
-    branches:
-      - master
-      - development
+    branches: [main, development]
 
 name: R-CMD-check
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   R-CMD-check:
     if: "!contains(github.event.commits[0].message, '[skip-ci]')"
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }}) (nosuggests ${{ matrix.config.nosuggests }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macOS-latest,   nosuggests: false, r: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'devel'}
-          - {os: windows-latest, nosuggests: false, r: 'release'}
-          - {os: windows-latest, nosuggests: false, r: 'oldrel'}
-          - {os: ubuntu-20.04,   nosuggests: false, r: 'devel'}
-          - {os: ubuntu-20.04,   nosuggests: false, r: 'release'}
-          - {os: ubuntu-20.04,   nosuggests: true,  r: 'release'}
-          - {os: ubuntu-20.04,   nosuggests: false, r: 'oldrel'}
-
-    env:
-      _R_CHECK_DEPENDS_ONLY_: ${{ matrix.config.nosuggests }}
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: PredictiveEcology/actions/install-spatial-deps@v0.1
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          extra-repositories: 'https://PredictiveEcology.r-universe.dev/'
-          Ncpus: 2
-          r-version: ${{ matrix.config.r }}
-          use-public-rspm: false
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: |
-            any::rcmdcheck
-            any::sf
-            any::XML
-            BioSIM=?ignore
-            fastshp=?ignore
-            NLMR=?ignore
-            PredictiveEcology/quickPlot@development
-            PredictiveEcology/reproducible@development
-            PredictiveEcology/Require@development
-            PredictiveEcology/SpaDES.core@development
-            PredictiveEcology/SpaDES.tools@development
-
-      - name: Install additional package dependencies
-        run: |
-          pak::pkg_install("remotes")
-          remotes::install_github("RNCan/BioSimClient_R")
-          remotes::install_github("s-u/fastshp")
-          remotes::install_github("ropensci/NLMR")
-        shell: Rscript {0}
-
-      - uses: r-lib/actions/check-r-package@v2
-        with:
-          upload-snapshots: true
+    uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main
+    secrets: inherit
+    with:
+      ## BioSIM::getModelOutput is referenced by LandR but not exported by
+      ## RNCan/BioSimClient_R — pre-existing WARNING tracked separately.
+      ## Drop this override once that's resolved.
+      error-on: '"error"'
+      ## Resolve only hard deps via `dependencies: NA`, then enumerate
+      ## Suggests explicitly below. pak's default ("all") recurses into
+      ## transitive Suggests and currently hits a "dependency conflict"
+      ## via tidyverse/ggplot2 (pulled by PredictiveEcology/quickPlot's
+      ## own Remotes). Listing the Suggests as top-level refs sidesteps
+      ## the deep-resolution issue.
+      dependencies: 'NA'
+      ## `BioSIM`/`NLMR`/`zonal`/`map` are not on CRAN under those names
+      ## (Github-only or removed); skip pak resolution and install via
+      ## post-install for the ones we actually need.
+      ## `santoku` was archived from CRAN on 2026-05-15, breaking the
+      ## transitive `mikejohnson51/zonal` -> `santoku` resolution (which
+      ## is why `zonal` is also dropped from DESCRIPTION's `Remotes:`).
+      extra-packages: |
+        any::sf
+        any::XML
+        arrow
+        bbmle
+        covr
+        curl
+        digest
+        dplyr
+        fasterize
+        future
+        future.apply
+        geodata
+        ggalluvial
+        ggpubr
+        ggrepel
+        googledrive
+        httr
+        lqmm
+        MASS
+        memuse
+        parallelly
+        purrr
+        qs2
+        rasterVis
+        RCurl
+        RhpcBLASctl
+        rlang
+        roxygen2
+        R.utils
+        SpaDES.core
+        spelling
+        testthat
+        withr
+        biomod2=?ignore
+        BioSIM=?ignore
+        NLMR=?ignore
+        map=?ignore
+        zonal=?ignore
+      post-install: |
+        pak::pkg_install("remotes")
+        remotes::install_github("RNCan/BioSimClient_R")
+        remotes::install_github("ropensci/NLMR")
+        remotes::install_github("CeresBarros/biomod2@dev_currentCeres")
+        remotes::install_github("PredictiveEcology/map@development")


### PR DESCRIPTION
## Problem
PRs targeting `main` (the default branch) don't run R-CMD-check at all. Two causes on `main`'s current `R-CMD-check.yaml`:

1. The `pull_request:` trigger filter lists only `[master, development]` — **`main` is absent**, so the matrix never fires for PRs into the default branch.
2. It's the stale pre-thin-caller workflow (`ubuntu-20.04`, `install-spatial-deps@v0.1`, `use-public-rspm: false`).

This is why e.g. #192 shows only `pkgdown` + GitGuardian — no R-CMD-check jobs.

## Fix
Adopt on `main` the same robust thin-caller already used on `development`, which delegates to the reusable workflow `PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main` (pandoc retry, stock-Noble spatial deps, macOS PROJ fix, pak-stable + `nick-fields/retry` fallback, the full LandR `extra-packages`/`post-install` dep block). Its trigger filter includes `main`, so the 8-config matrix runs on PRs to `main`.

No change to the matrix breadth here (8 configs); widening to reproducible's 10 is deferred until we confirm this runs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)