### PR TITLE
skip network-dependent tests/examples on CI (keep them running locally)

### DIFF
--- a/R/prepInputObjects.R
+++ b/R/prepInputObjects.R
@@ -852,7 +852,9 @@ prepRawBiomassMap <- function(dataSource = "SCANFI", dataYear = "2020", dataVers
 #'
 #' @export
 #'
-#' @examples
+#' @examplesIf !isTRUE(as.logical(Sys.getenv("CI")))
+#' ## NOTE: runs locally, skipped on CI -- downloads NFDB_poly.zip from
+#' ## cwfis.cfs.nrcan.gc.ca (same predicate as testthat::skip_on_ci())
 #' withr::local_options(list(
 #'   reproducible.useTerra = TRUE,
 #'   reproducible.rasterRead = "terra::rast"

--- a/R/studyArea.R
+++ b/R/studyArea.R
@@ -20,7 +20,9 @@ randomStudyArea <- utils::getFromNamespace("randomStudyArea", "SpaDES.tools")
 #'
 #' @returns spatial polygons object of the same class as `studyArea`
 #'
-#' @examples
+#' @examplesIf !isTRUE(as.logical(Sys.getenv("CI")))
+#' ## NOTE: runs locally, skipped on CI -- downloads from sis.agr.gc.ca, which throttles
+#' ## connections from CI runners (same predicate as testthat::skip_on_ci())
 #' ## using SpatVector objects
 #' sa <- randomStudyArea(size = 1e9)
 #' sa_eco <- studyAreaEco(studyArea = sa)

--- a/man/prepInputsFireYear.Rd
+++ b/man/prepInputsFireYear.Rd
@@ -24,6 +24,9 @@ a \code{SpatRaster} layer of fire perimeters with fire year values.
 Create a raster of fire perimeters
 }
 \examples{
+\dontshow{if (!isTRUE(as.logical(Sys.getenv("CI")))) withAutoprint(\{ # examplesIf}
+## NOTE: runs locally, skipped on CI -- downloads NFDB_poly.zip from
+## cwfis.cfs.nrcan.gc.ca (same predicate as testthat::skip_on_ci())
 withr::local_options(list(
   reproducible.useTerra = TRUE,
   reproducible.rasterRead = "terra::rast"
@@ -56,5 +59,5 @@ if (interactive()) {
 }
 
 withr::deferred_run()
-
+\dontshow{\}) # examplesIf}
 }

--- a/man/studyAreaEco.Rd
+++ b/man/studyAreaEco.Rd
@@ -26,6 +26,9 @@ spatial polygons object of the same class as \code{studyArea}
 Extend a study area boundary to include the full ecological boundary polygons intersecting it.
 }
 \examples{
+\dontshow{if (!isTRUE(as.logical(Sys.getenv("CI")))) withAutoprint(\{ # examplesIf}
+## NOTE: runs locally, skipped on CI -- downloads from sis.agr.gc.ca, which throttles
+## connections from CI runners (same predicate as testthat::skip_on_ci())
 ## using SpatVector objects
 sa <- randomStudyArea(size = 1e9)
 sa_eco <- studyAreaEco(studyArea = sa)
@@ -39,5 +42,5 @@ if (interactive()) {
     geom_sf(data = sa_eco_sf, fill = "gray") +
     geom_sf(data = sa_sf, fill = "violet", alpha = 0.3)
 }
-
+\dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-summarizeCanadianForestRasters.R
+++ b/tests/testthat/test-summarizeCanadianForestRasters.R
@@ -1,6 +1,9 @@
 test_that("calc_raster_stats and plot_raster_stats work", {
   testthat::skip_on_cran()
-  # testthat::skip_on_ci()
+
+  ## NOTE: downloads from sis.agr.gc.ca, which throttles connections from CI runners
+  ## (connection-level failure; not a cert or User-Agent problem). Still runs locally.
+  testthat::skip_on_ci()
 
   testthat::skip_if_not_installed("dplyr")
   testthat::skip_if_not_installed("geodata")


### PR DESCRIPTION
`R CMD check` on GitHub has been failing intermittently on downloads from `sis.agr.gc.ca`. This makes the network-dependent tests and examples skip on CI while **still running locally**.

Independent of #197 (branched from `development`), though it's what makes that PR's CI green.

## Diagnosis: connection throttling, not a client problem

Ruled out both plausible causes:

- **Not certificates.** The host presents a complete, valid 4-cert chain (leaf → Entrust OV TLS Issuing RSA CA 2 → Sectigo Root R46 → USERTrust RSA CA) that verifies against system roots alone, `Verify return code: 0 (ok)`. Decisively: cert/trust failures are *deterministic per platform*, yet windows-latest (release) failed on one run and passed on the re-run.
- **Not User-Agent bot detection.** The server returns HTTP 206 identically to no UA, `libcurl/r-curl/httr2`, R's own UA, and Chrome's.

What it does track is **concurrency**: a 7-job matrix hitting the host at once lost 3 jobs; a 3-job re-run lost 1. The error is connection-level — `open.connection(): cannot open the connection`, no TLS diagnostic — i.e. dropped/refused SYNs. That is per-source throttling of GitHub's address ranges, and there's nothing fixable client-side.

## Three unguarded consumers; the rest already were

| what | host | status before |
|---|---|---|
| `test-summarizeCanadianForestRasters.R` | sis.agr.gc.ca | unguarded (a commented-out `skip_on_ci()` was already sitting there) |
| `studyAreaEco()` example | sis.agr.gc.ca | unguarded — **2 of the 3 original errors** |
| `prepInputsFireYear()` example | cwfis.cfs.nrcan.gc.ca | unguarded, ~55 s every CI job; hasn't flaked yet |

`studyAreaEco` is the one worth calling out: it downloads via the function's *own default url*, so it isn't found by grepping examples for URLs — only by checking which examples call downloading functions. It failed in both `checking examples` and `--run-donttest`.

Already guarded, left alone: `test-prepRawBiomassMap` and `test-speciesInStudyArea` (both `skip_on_ci()`, same host), `test-loadkNNSpeciesLayers` (`interactive()`), `test-wardDispersalFunction` (Drive token), and `raster_stats()` examples (wrapped in `if (interactive())`, which `R CMD check` never enters).

## Why `@examplesIf` rather than `\dontrun{}`

The examples must keep running locally. `\dontrun{}` never runs anywhere, and `\donttest{}` is insufficient because `--run-donttest` executes it — that's precisely how `studyAreaEco` failed twice in one job. `@examplesIf !isTRUE(as.logical(Sys.getenv("CI")))` uses the same predicate as `testthat::skip_on_ci()`, so behaviour is consistent between tests and examples.

## Verified

```
CI=true  NOT_CRAN=true  ->  SKIP  "Reason: On CI"
CI unset NOT_CRAN=true  ->  [ FAIL 0 | WARN 0 | SKIP 0 | PASS 1 ]
```

(If you test this locally and see it *not* skip, check `~/.Renviron` — a personal `CI=false` there will mask it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
