### PR TITLE
regenerate docs under roxygen2 8.1.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -153,4 +153,4 @@ Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 3
 Config/testthat/parallel: true
 Config/testthat/start-first: prep*
-Config/roxygen2/version: 8.0.0
+Config/roxygen2/version: 8.1.0

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -177,179 +177,215 @@ import(methods)
 import(patchwork)
 importFrom(Formula,Formula)
 importFrom(MuMIn,r.squaredGLMM)
-importFrom(RColorBrewer,brewer.pal)
-importFrom(RColorBrewer,brewer.pal.info)
+importFrom(RColorBrewer,
+  brewer.pal,
+  brewer.pal.info
+)
 importFrom(Rcpp,evalCpp)
-importFrom(SpaDES.tools,inRange)
-importFrom(SpaDES.tools,neutralLandscapeMap)
-importFrom(SpaDES.tools,randomPolygons)
-importFrom(SpaDES.tools,rasterizeReduced)
-importFrom(SpaDES.tools,runifC)
-importFrom(SpaDES.tools,spread2)
-importFrom(cli,col_blue)
-importFrom(cli,col_cyan)
-importFrom(cli,col_green)
-importFrom(cli,col_magenta)
-importFrom(cli,col_red)
-importFrom(data.table,as.data.table)
-importFrom(data.table,copy)
-importFrom(data.table,data.table)
-importFrom(data.table,dcast)
-importFrom(data.table,fifelse)
-importFrom(data.table,fread)
-importFrom(data.table,is.data.table)
-importFrom(data.table,last)
-importFrom(data.table,melt)
-importFrom(data.table,rbindlist)
-importFrom(data.table,set)
-importFrom(data.table,setDT)
-importFrom(data.table,setDTthreads)
-importFrom(data.table,setattr)
-importFrom(data.table,setcolorder)
-importFrom(data.table,setkey)
-importFrom(data.table,setkeyv)
-importFrom(data.table,setnames)
-importFrom(data.table,setorderv)
-importFrom(fpCompare,"%<<%")
-importFrom(fpCompare,"%<=%")
-importFrom(fpCompare,"%==%")
-importFrom(fpCompare,"%>>%")
-importFrom(ggspatial,annotation_north_arrow)
-importFrom(ggspatial,layer_spatial)
-importFrom(ggspatial,north_arrow_minimal)
-importFrom(grDevices,colorRampPalette)
-importFrom(grDevices,dev.off)
-importFrom(grDevices,png)
+importFrom(SpaDES.tools,
+  inRange,
+  neutralLandscapeMap,
+  randomPolygons,
+  rasterizeReduced,
+  runifC,
+  spread2
+)
+importFrom(cli,
+  col_blue,
+  col_cyan,
+  col_green,
+  col_magenta,
+  col_red
+)
+importFrom(data.table,
+  as.data.table,
+  copy,
+  data.table,
+  dcast,
+  fifelse,
+  fread,
+  is.data.table,
+  last,
+  melt,
+  rbindlist,
+  set,
+  setDT,
+  setDTthreads,
+  setattr,
+  setcolorder,
+  setkey,
+  setkeyv,
+  setnames,
+  setorderv
+)
+importFrom(fpCompare,
+  "%<<%",
+  "%<=%",
+  "%==%",
+  "%>>%"
+)
+importFrom(ggspatial,
+  annotation_north_arrow,
+  layer_spatial,
+  north_arrow_minimal
+)
+importFrom(grDevices,
+  colorRampPalette,
+  dev.off,
+  png
+)
 importFrom(httr2,request)
-importFrom(lme4,glmer)
-importFrom(lme4,lmer)
+importFrom(lme4,
+  glmer,
+  lmer
+)
 importFrom(parallel,mclapply)
-importFrom(pemisc,factorValues2)
-importFrom(pemisc,termsInData)
-importFrom(quickPlot,"setColors<-")
-importFrom(quickPlot,Plot)
-importFrom(quickPlot,layerNames)
-importFrom(quickPlot,numLayers)
-importFrom(quickPlot,setColors)
-importFrom(raster,"NAvalue<-")
-importFrom(raster,calc)
-importFrom(raster,deratify)
-importFrom(raster,dropLayer)
-importFrom(raster,extension)
-importFrom(raster,levels)
-importFrom(raster,projectExtent)
-importFrom(raster,raster)
-importFrom(raster,rasterOptions)
-importFrom(raster,ratify)
-importFrom(raster,reclassify)
-importFrom(raster,stack)
-importFrom(raster,unstack)
-importFrom(reproducible,.prefix)
-importFrom(reproducible,.requireNamespace)
-importFrom(reproducible,.sortDotsUnderscoreFirst)
-importFrom(reproducible,.suffix)
-importFrom(reproducible,Cache)
-importFrom(reproducible,CacheDigest)
-importFrom(reproducible,Filenames)
-importFrom(reproducible,asPath)
-importFrom(reproducible,basename2)
-importFrom(reproducible,cropInputs)
-importFrom(reproducible,fixErrors)
-importFrom(reproducible,maxFn)
-importFrom(reproducible,messageDF)
-importFrom(reproducible,minFn)
-importFrom(reproducible,paddedFloatToChar)
-importFrom(reproducible,postProcess)
-importFrom(reproducible,postProcessTerra)
-importFrom(reproducible,postProcessTo)
-importFrom(reproducible,preProcess)
-importFrom(reproducible,prepInputs)
-importFrom(reproducible,projectInputs)
-importFrom(reproducible,rasterRead)
-importFrom(reproducible,writeOutputs)
-importFrom(reproducible,writeTo)
-importFrom(sf,as_Spatial)
-importFrom(sf,st_as_sf)
-importFrom(sf,st_cast)
-importFrom(sf,st_coordinates)
-importFrom(sf,st_crs)
-importFrom(sf,st_intersects)
-importFrom(sf,st_read)
-importFrom(sf,st_transform)
-importFrom(sf,st_union)
-importFrom(sf,st_zm)
-importFrom(sp,CRS)
-importFrom(sp,SpatialPoints)
-importFrom(sp,proj4string)
-importFrom(stats,approx)
-importFrom(stats,as.formula)
-importFrom(stats,complete.cases)
-importFrom(stats,fitted)
-importFrom(stats,glm)
-importFrom(stats,na.omit)
-importFrom(stats,predict)
-importFrom(stats,quantile)
-importFrom(stats,runif)
-importFrom(stats,setNames)
-importFrom(stats,terms)
-importFrom(stats,update)
-importFrom(stats,vcov)
-importFrom(terra,"NAflag<-")
-importFrom(terra,"coltab<-")
-importFrom(terra,"crs<-")
-importFrom(terra,app)
-importFrom(terra,as.factor)
-importFrom(terra,as.int)
-importFrom(terra,cellFromRowCol)
-importFrom(terra,cellFromXY)
-importFrom(terra,classify)
-importFrom(terra,compareGeom)
-importFrom(terra,crop)
-importFrom(terra,crosstab)
-importFrom(terra,crs)
-importFrom(terra,deepcopy)
-importFrom(terra,ext)
-importFrom(terra,extract)
-importFrom(terra,focalMat)
-importFrom(terra,intersect)
-importFrom(terra,is.factor)
-importFrom(terra,is.int)
-importFrom(terra,is.points)
-importFrom(terra,is.valid)
-importFrom(terra,levels)
-importFrom(terra,mask)
-importFrom(terra,minmax)
-importFrom(terra,ncell)
-importFrom(terra,nlyr)
-importFrom(terra,project)
-importFrom(terra,rast)
-importFrom(terra,rasterize)
-importFrom(terra,res)
-importFrom(terra,rowColFromCell)
-importFrom(terra,set.names)
-importFrom(terra,set.values)
-importFrom(terra,terraOptions)
-importFrom(terra,unique)
-importFrom(terra,values)
-importFrom(terra,vect)
-importFrom(terra,writeRaster)
-importFrom(terra,xmax)
-importFrom(terra,xmin)
-importFrom(terra,xyFromCell)
-importFrom(terra,ymax)
-importFrom(terra,ymin)
+importFrom(pemisc,
+  factorValues2,
+  termsInData
+)
+importFrom(quickPlot,
+  "setColors<-",
+  Plot,
+  layerNames,
+  numLayers,
+  setColors
+)
+importFrom(raster,
+  "NAvalue<-",
+  calc,
+  deratify,
+  dropLayer,
+  extension,
+  levels,
+  projectExtent,
+  raster,
+  rasterOptions,
+  ratify,
+  reclassify,
+  stack,
+  unstack
+)
+importFrom(reproducible,
+  .prefix,
+  .requireNamespace,
+  .sortDotsUnderscoreFirst,
+  .suffix,
+  Cache,
+  CacheDigest,
+  Filenames,
+  asPath,
+  basename2,
+  cropInputs,
+  fixErrors,
+  maxFn,
+  messageDF,
+  minFn,
+  paddedFloatToChar,
+  postProcess,
+  postProcessTerra,
+  postProcessTo,
+  preProcess,
+  prepInputs,
+  projectInputs,
+  rasterRead,
+  writeOutputs,
+  writeTo
+)
+importFrom(sf,
+  as_Spatial,
+  st_as_sf,
+  st_cast,
+  st_coordinates,
+  st_crs,
+  st_intersects,
+  st_read,
+  st_transform,
+  st_union,
+  st_zm
+)
+importFrom(sp,
+  CRS,
+  SpatialPoints,
+  proj4string
+)
+importFrom(stats,
+  approx,
+  as.formula,
+  complete.cases,
+  fitted,
+  glm,
+  na.omit,
+  predict,
+  quantile,
+  runif,
+  setNames,
+  terms,
+  update,
+  vcov
+)
+importFrom(terra,
+  "NAflag<-",
+  "coltab<-",
+  "crs<-",
+  app,
+  as.factor,
+  as.int,
+  cellFromRowCol,
+  cellFromXY,
+  classify,
+  compareGeom,
+  crop,
+  crosstab,
+  crs,
+  deepcopy,
+  ext,
+  extract,
+  focalMat,
+  intersect,
+  is.factor,
+  is.int,
+  is.points,
+  is.valid,
+  levels,
+  mask,
+  minmax,
+  ncell,
+  nlyr,
+  project,
+  rast,
+  rasterize,
+  res,
+  rowColFromCell,
+  set.names,
+  set.values,
+  terraOptions,
+  unique,
+  values,
+  vect,
+  writeRaster,
+  xmax,
+  xmin,
+  xyFromCell,
+  ymax,
+  ymin
+)
 importFrom(tidyterra,geom_spatraster)
-importFrom(tools,file_ext)
-importFrom(tools,file_path_sans_ext)
-importFrom(utils,capture.output)
-importFrom(utils,combn)
-importFrom(utils,count.fields)
-importFrom(utils,data)
-importFrom(utils,getFromNamespace)
-importFrom(utils,head)
-importFrom(utils,install.packages)
-importFrom(utils,str)
-importFrom(utils,tail)
-importFrom(utils,untar)
+importFrom(tools,
+  file_ext,
+  file_path_sans_ext
+)
+importFrom(utils,
+  capture.output,
+  combn,
+  count.fields,
+  data,
+  getFromNamespace,
+  head,
+  install.packages,
+  str,
+  tail,
+  untar
+)
 importFrom(viridis,scale_fill_viridis)
 useDynLib(LandR, .registration = TRUE)

--- a/man/convertUnwantedLCC.Rd
+++ b/man/convertUnwantedLCC.Rd
@@ -71,10 +71,10 @@ be used for the simpler cases of simply replacing a Land Cover Class.
 Each pixel whose value is in \code{classesToReplace} is assigned the \emph{nearest} available
 \code{initialEcoregionCode}. For each candidate land-cover class present in \code{rstLCC}, the
 distance from every pixel to the nearest cell of that class is computed with a single
-vectorized \code{\link[terra:distance]{terra::distance()}} call; each unwanted pixel is then
-given the closest class whose implied \code{initialEcoregionCode} is available for that pixel's
-ecoregion (and all of its \code{speciesCode}s). Ties break to the lowest land-cover class, so
-the result is deterministic. This replaces an earlier iterative \code{spread2()}-based search
+vectorized \code{\link[terra:distance]{terra::distance()}} call; each unwanted pixel is then given the closest
+class whose implied \code{initialEcoregionCode} is available for that pixel's ecoregion
+(and all of its \code{speciesCode}s). Ties break to the lowest land-cover class, so the
+result is deterministic. This replaces an earlier iterative \code{spread2()}-based search
 whose run time grew with the square of the radius of the largest contiguous block of
 \code{classesToReplace}, which could take hours on large study areas with big lakes or burns.
 }


### PR DESCRIPTION
Pure formatting, no semantic change. Split out so the reformatting doesn't bury unrelated work — it would otherwise leak into any PR whose author happens to run `document()` on 8.1.0 (which is how it surfaced, during #198).

## What changed

**`NAMESPACE`** — 8.1.0 groups imports per package:

```r
importFrom(RColorBrewer,
  brewer.pal,
  brewer.pal.info
)
```

instead of one `importFrom()` per symbol. That's 376 lines of diff for zero behaviour change.

**Verified equivalent**, rather than eyeballed: both files parsed and their directive sets normalised and compared — **353 directives before, 353 after, sets identical**.

**`DESCRIPTION`** — `Config/roxygen2/version: 8.0.0 → 8.1.0`.

**`man/convertUnwantedLCC.Rd`** — re-wrapped. This one was already stale against 8.0.0, so it's a pre-existing drift being cleaned up here.

## Note for the team

Until everyone's roxygen2 is `>= 8.1.0`, the next person to run `document()` on 8.0.0 will silently revert the NAMESPACE format. The `Config/roxygen2/version` field makes that visible in the diff, at least.

Sequenced after #198 and before updating #197, so the `convertUnwantedLCC.Rd` re-wrap is resolved once rather than conflicting across branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)