### PR TITLE
GHA: remove unused packages and update actions versions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   R-CMD-check:
-    if: "!contains(github.event.commits[0].message, '[skip-ci]')"
     uses: PredictiveEcology/actions/.github/workflows/R-CMD-check.yaml@main
     secrets: inherit
     with:
@@ -28,12 +27,8 @@ jobs:
       ## own Remotes). Listing the Suggests as top-level refs sidesteps
       ## the deep-resolution issue.
       dependencies: 'NA'
-      ## `BioSIM`/`NLMR`/`zonal`/`map` are not on CRAN under those names
-      ## (Github-only or removed); skip pak resolution and install via
-      ## post-install for the ones we actually need.
-      ## `santoku` was archived from CRAN on 2026-05-15, breaking the
-      ## transitive `mikejohnson51/zonal` -> `santoku` resolution (which
-      ## is why `zonal` is also dropped from DESCRIPTION's `Remotes:`).
+      ## `BioSIM`/`map` are not on CRAN under those names (GitHub-only);
+      ## skip pak resolution for them and install via post-install below.
       extra-packages: |
         any::sf
         any::XML
@@ -70,12 +65,9 @@ jobs:
         withr
         biomod2=?ignore
         BioSIM=?ignore
-        NLMR=?ignore
         map=?ignore
-        zonal=?ignore
       post-install: |
         pak::pkg_install("remotes")
         remotes::install_github("RNCan/BioSimClient_R")
-        remotes::install_github("ropensci/NLMR")
         remotes::install_github("CeresBarros/biomod2@dev_currentCeres")
         remotes::install_github("PredictiveEcology/map@development")

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -37,14 +37,12 @@ jobs:
             any::XML
             local::.
             BioSIM=?ignore
-            NLMR=?ignore
           needs: website
 
       - name: Install additional package dependencies
         run: |
           pak::pkg_install("remotes")
           remotes::install_github("RNCan/BioSimClient_R")
-          remotes::install_github("ropensci/NLMR")
         shell: Rscript {0}
 
       - name: Build site

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -13,7 +13,6 @@ concurrency:
 
 jobs:
   test-coverage:
-    if: "!contains(github.event.commits[0].message, '[skip-ci]')"
     uses: PredictiveEcology/actions/.github/workflows/test-coverage.yaml@main
     secrets: inherit
     with:
@@ -55,12 +54,9 @@ jobs:
         withr
         biomod2=?ignore
         BioSIM=?ignore
-        NLMR=?ignore
         map=?ignore
-        zonal=?ignore
       post-install: |
         pak::pkg_install("remotes")
         remotes::install_github("RNCan/BioSimClient_R")
-        remotes::install_github("ropensci/NLMR")
         remotes::install_github("CeresBarros/biomod2@dev_currentCeres")
         remotes::install_github("PredictiveEcology/map@development")


### PR DESCRIPTION
Housekeeping on the workflow files that LandR owns. No change to what is actually checked.

## Remove two packages that are not used

`zonal` and `NLMR` each have **0 references in `R/`, `tests/`, `vignettes/` or `inst/`, and 0 entries in `DESCRIPTION`**. `zonal` was already dropped from `Remotes:` when `santoku` was archived; `NLMR` appears to be a leftover.

Both were listed as `?ignore` (so pak skipped resolving them) *and* `NLMR` was still being installed from GitHub in `post-install`. Removing:

- `NLMR=?ignore` and `zonal=?ignore` from `R-CMD-check.yaml` and `test-coverage.yaml`
- `remotes::install_github("ropensci/NLMR")` from both `post-install` blocks
- the same two lines from `pkgdown.yaml`

That drops one source install from every matrix leg (8 on R-CMD-check, plus coverage and pkgdown), and removes one third-party repo from the set whose code runs during CI.

The comment above `extra-packages` described the santoku → `zonal` resolution failure and a `Remotes:` entry that no longer exists, so it has been cut down to what is still true:

```yaml
## `BioSIM`/`map` are not on CRAN under those names (GitHub-only);
## skip pak resolution for them and install via post-install below.
```

`biomod2`, `BioSIM` and `map` are all genuinely used (30, 11 and 1 references) and are untouched.

## Update `pkgdown.yaml`

`actions/checkout@v4` → `@v7`. This workflow was never converted to a thin caller, so its action versions had drifted furthest behind — three majors. `v6` was the release that moved to Node.js 24, so this also clears the Node 20 deprecation warning for this workflow. Its other actions (`r-lib/actions/*@v2`, `JamesIves/github-pages-deploy-action@v4`) are already current.

## Drop the `[skip-ci]` guard

```yaml
if: "!contains(github.event.commits[0].message, '[skip-ci]')"
```

This is redundant with GitHub's [built-in skip keywords](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/skip-workflow-runs), and the built-in mechanism is better in three ways:

- it applies to `pull_request` as well as `push`, whereas `github.event.commits` is null on pull requests, so the guard only ever worked on pushes;
- it prevents the run being created at all, rather than creating a run whose job evaluates to skipped;
- it matches the documented tokens (`[skip ci]`, `[ci skip]`, `[no ci]`, `[skip actions]`, `[actions skip]`). The guard matched `[skip-ci]` — hyphenated — which is not one of them, so typing the documented form did nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)