### PR TITLE
Explain SCANFI download failures to users without access (closes #163)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ URL:
     https://landr.predictiveecology.org,
     https://github.com/PredictiveEcology/LandR
 Date: 2026-08-23
-Version: 1.2.0.9009
+Version: 1.2.0.9010
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),
@@ -142,6 +142,7 @@ Collate:
     'prepInputObjects.R'
     'prepInputs_NTEMS.R'
     'prepSpeciesLayers.R'
+    'scanfi-access.R'
     'seedDispersalLANDIS.R'
     'serotiny-resprouting.R'
     'speciesPresentFromKNN.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -53,6 +53,17 @@
 
 ## Enhancements
 
+* SCANFI download failures now explain themselves (closes #163). SCANFI is distributed
+  through a Google Drive folder shared with collaborators, so a user without access saw only
+  `reproducible`'s generic `Could not access the Google Drive resource ... (404) Not Found`.
+  That reads like a dead link and invites a hunt for a public mirror that does not exist.
+  `prepInputsStandAgeMap()`, `prepRawBiomassMap()`, `loadSCANFISpeciesLayers()`,
+  `convert_SCANFI_LCC_codes()` and `prepInputs_SCANFI_LCC_FAO()` now report it as a
+  permissions problem, point at <https://opendata.nfis.org/> to request access, and name the
+  ways out -- supplying your own copy, or `dataSource = "KNN"` / `"NTEMS"` where the function
+  offers them. The underlying error is still shown in full, and failures that are *not* access
+  problems pass through untouched;
+
 * `convertUnwantedLCC()` no longer uses the iterative `spread2()` search, whose run time grew
   with the square of the radius of the largest contiguous block of `classesToReplace`. On
   study areas containing large lakes/burns masked to an irregular boundary that search could

--- a/R/maps.R
+++ b/R/maps.R
@@ -307,7 +307,13 @@ convert_SCANFI_LCC_codes <- function(year = 2000, dataVersion = "V2", writeTo = 
   dots$url <- lccURL
   dots$targetFile <- lccTF
 
-  scanfi_lcc <- do.call(prepInputs, dots)
+  scanfi_lcc <- .withSCANFIAccess(
+    do.call(prepInputs, dots),
+    what = "the SCANFI land cover map",
+    dataYear = year,
+    dataVersion = dataVersion,
+    urlArg = "url"
+  )
 
   ## Bryoids, herbs, rock/exposed, shrubs, broadleaf, conifer, mixedwood, water
   oldVals <- 1:8
@@ -435,7 +441,13 @@ prepInputs_SCANFI_LCC_FAO <- function(
   dots$method <- resampleMethod
   dots$writeTo <- newFilename
   # digs <- .robustDigest(dots)
-  lcc <- do.call(prepInputs, dots) # |>
+  lcc <- .withSCANFIAccess(
+    do.call(prepInputs, dots),
+    what = "the SCANFI land cover map",
+    dataYear = year,
+    dataVersion = dataVersion,
+    urlArg = "url"
+  ) # |>
   #  Cache(.functionName = paste0("prepInputs_NTEMS_LCC_FAO_", year),
   #        omitArgs = c("targetFile", "writeTo"),
   #        .cacheExtra = digs)
@@ -1548,7 +1560,13 @@ loadSCANFISpeciesLayers <- function(
     }
   }
 
-  driveFiles <- as.data.table(googledrive::with_drive_quiet(googledrive::drive_ls(url)))
+  driveFiles <- .withSCANFIAccess(
+    as.data.table(googledrive::with_drive_quiet(googledrive::drive_ls(url))),
+    what = "the SCANFI species layers",
+    dataYear = year,
+    dataVersion = dataVersion,
+    urlArg = "url"
+  )
   driveFiles <- driveFiles[grepl("SCANFI_sps", name)] ## selecting just species layers
   driveFiles <- driveFiles[grep("tif.", name, invert = TRUE)] ## removing .ovr and .aux files
   if (dataVersion == "V2") {
@@ -1685,22 +1703,28 @@ loadSCANFISpeciesLayers <- function(
 
   URLs <- fileURLs[targetFiles]
 
-  speciesLayers <- Map(
-    function(tf, url, outFile) {
-      prepInputs(
-        url = url,
-        to = rasterToMatch,
-        destinationPath = dPath,
-        method = "bilinear",
-        writeTo = outFile,
-        overwrite = TRUE
-      )
-    },
-    tf = file.path(dPath, targetFiles),
-    url = URLs,
-    outFile = file.path(oPath, postProcessedFilenamesWithStudyAreaName)
-  ) |>
-    Cache(.functionName = "prepInputs_speciesLayers")
+  speciesLayers <- .withSCANFIAccess(
+    Map(
+      function(tf, url, outFile) {
+        prepInputs(
+          url = url,
+          to = rasterToMatch,
+          destinationPath = dPath,
+          method = "bilinear",
+          writeTo = outFile,
+          overwrite = TRUE
+        )
+      },
+      tf = file.path(dPath, targetFiles),
+      url = URLs,
+      outFile = file.path(oPath, postProcessedFilenamesWithStudyAreaName)
+    ) |>
+      Cache(.functionName = "prepInputs_speciesLayers"),
+    what = "the SCANFI species layers",
+    dataYear = year,
+    dataVersion = dataVersion,
+    urlArg = "url"
+  )
 
   # if (is.null(studyArea) && is.null(rasterToMatch)) {
   #   speciesLayers <- Map(

--- a/R/prepInputObjects.R
+++ b/R/prepInputObjects.R
@@ -501,16 +501,23 @@ prepInputsStandAgeMap <- function(
       #SCANFI V1 has only one dataYear so age is adjusted using NTEMS disturbance layers
       ageURL <- paste0("https://drive.google.com/file/d/1OdZ7Tznk53KceEyt9dFOBOkxDHEX5X0U")
 
-      standAgeMap <- prepInputs(
-        url = ageURL,
-        destinationPath = destinationPath,
-        datatype = datatype,
-        method = method,
-        fun = ageFun,
-        datatype = datatype,
-        to = rasterToMatch,
-        ...
-      ) |> Cache(.functionName = "prepInputs_ageMapFromSCANFI")
+      standAgeMap <- .withSCANFIAccess(
+        prepInputs(
+          url = ageURL,
+          destinationPath = destinationPath,
+          datatype = datatype,
+          method = method,
+          fun = ageFun,
+          datatype = datatype,
+          to = rasterToMatch,
+          ...
+        ) |> Cache(.functionName = "prepInputs_ageMapFromSCANFI"),
+        what = "the SCANFI stand age map",
+        dataYear = dataYear,
+        dataVersion = dataVersion,
+        urlArg = "ageURL",
+        alternatives = c("KNN", "NTEMS")
+      )
 
       if (dataYear != "2020") {
         #use NTEMS to identify disturbances (harvest and fire) that occurred between dataYear and 2020
@@ -605,16 +612,23 @@ prepInputsStandAgeMap <- function(
         stop("SCANFI V2 data is currently available for 1985, 1990, 1995, 2000, 2005, 2010, 2015, 2020, and 2025 only")
       }
 
-      standAgeMap <- prepInputs(
-        url = ageURL,
-        destinationPath = destinationPath,
-        datatype = datatype,
-        method = method,
-        fun = ageFun,
-        datatype = datatype,
-        to = rasterToMatch,
-        ...
-      ) |> Cache(.functionName = "prepInputs_ageMapFromSCANFI")
+      standAgeMap <- .withSCANFIAccess(
+        prepInputs(
+          url = ageURL,
+          destinationPath = destinationPath,
+          datatype = datatype,
+          method = method,
+          fun = ageFun,
+          datatype = datatype,
+          to = rasterToMatch,
+          ...
+        ) |> Cache(.functionName = "prepInputs_ageMapFromSCANFI"),
+        what = "the SCANFI stand age map",
+        dataYear = dataYear,
+        dataVersion = dataVersion,
+        urlArg = "ageURL",
+        alternatives = c("KNN", "NTEMS")
+      )
 
     }
   }
@@ -835,8 +849,16 @@ prepRawBiomassMap <- function(dataSource = "SCANFI", dataYear = "2020", dataVers
     Args2$quick <- c("writeTo")
   }
 
-  rawBiomassMap <- do.call(prepInputs, args = Args) |>
-    Cache(quick = Args2$quick, .functionName = "prepInputsRawBiomassMap", omitArgs = Args2$omitArgs)
+  rawBiomassMap <- .withSCANFIAccess(
+    do.call(prepInputs, args = Args) |>
+      Cache(quick = Args2$quick, .functionName = "prepInputsRawBiomassMap", omitArgs = Args2$omitArgs),
+    what = "the SCANFI biomass map",
+    dataYear = dataYear,
+    dataVersion = dataVersion,
+    urlArg = "url",
+    alternatives = c("KNN", "NTEMS"),
+    enabled = identical(dataSource, "SCANFI")
+  )
 
   return(rawBiomassMap)
 }

--- a/R/scanfi-access.R
+++ b/R/scanfi-access.R
@@ -1,0 +1,91 @@
+## ---------------------------------------------------------------------------
+## Messaging for users without SCANFI access
+##
+## SCANFI is distributed through a Google Drive folder shared with collaborators
+## rather than published openly. A user who has not been granted access gets only
+## reproducible's generic failure -- "Could not access the Google Drive resource
+## ... Client error: (404) Not Found" -- which reads like a dead link and invites
+## a hunt for a mirror that does not exist. It is a permissions problem, so say
+## so, and name the ways out.
+## ---------------------------------------------------------------------------
+
+## Official SCANFI distribution point; where to ask for access.
+.scanfiAccessURL <- "https://opendata.nfis.org/"
+
+## Does this error look like Google Drive refusing us a file? Matches both the
+## wrapper reproducible raises and the underlying googledrive status text, since
+## which of them surfaces depends on where the request failed. A bare status code
+## is enough here because this is only ever applied to a known Drive fetch.
+.isGoogleDriveAccessError <- function(e) {
+  msg <- paste(conditionMessage(e), collapse = "\n")
+
+  grepl("google drive", msg, ignore.case = TRUE) ||
+    grepl("(^|[^0-9])(401|403|404)([^0-9]|$)", msg) ||
+    grepl("not found|permission|access denied|forbidden|unauthorized", msg, ignore.case = TRUE)
+}
+
+.scanfiAccessMessage <- function(e, what, dataYear = NULL, dataVersion = NULL,
+                                 urlArg = NULL, alternatives = NULL) {
+  qualifier <- paste(c(dataVersion, dataYear), collapse = " ")
+
+  ways <- c(
+    paste0(
+      "request access to the SCANFI data from the SCANFI team (see ",
+      .scanfiAccessURL, "), then re-authenticate with googledrive::drive_auth()"
+    ),
+    if (!is.null(urlArg)) {
+      paste0("or, if you already have the data, pass it via `", urlArg, "`")
+    },
+    if (length(alternatives)) {
+      paste0(
+        "or use a different data source: ",
+        paste0('dataSource = "', alternatives, '"', collapse = " or ")
+      )
+    }
+  )
+
+  paste0(
+    "Could not download ", what,
+    if (nzchar(qualifier)) paste0(" (", qualifier, ")") else "", ".\n\n",
+    "SCANFI is distributed through a restricted Google Drive folder, so this is\n",
+    "usually a permissions problem rather than a broken link: the Google account\n",
+    "you are authenticated as may not have been granted access.\n\n",
+    "To resolve it:\n",
+    paste(
+      vapply(
+        ways,
+        function(w) paste(strwrap(w, width = 76, initial = "  * ", prefix = "    "),
+                          collapse = "\n"),
+        character(1)
+      ),
+      collapse = "\n"
+    ), "\n\n",
+    "Original error:\n",
+    paste0("  ", strsplit(paste(conditionMessage(e), collapse = "\n"), "\n")[[1]],
+           collapse = "\n")
+  )
+}
+
+## Wrap a SCANFI download so an access failure explains itself. Anything that is
+## not a Drive access problem is re-thrown untouched. `enabled` lets functions
+## that serve several data sources wrap the call in place, without duplicating it
+## for the SCANFI and non-SCANFI branches.
+.withSCANFIAccess <- function(expr, what, dataYear = NULL, dataVersion = NULL,
+                              urlArg = NULL, alternatives = NULL, enabled = TRUE) {
+  if (!isTRUE(enabled)) {
+    return(expr)
+  }
+
+  tryCatch(
+    expr,
+    error = function(e) {
+      if (!.isGoogleDriveAccessError(e)) {
+        stop(e)
+      }
+      stop(
+        .scanfiAccessMessage(e, what, dataYear, dataVersion, urlArg, alternatives),
+        call. = FALSE
+      )
+    }
+  )
+}

--- a/tests/testthat/test-scanfi-access.R
+++ b/tests/testthat/test-scanfi-access.R
@@ -1,0 +1,84 @@
+drive_error <- function(status = "Client error: (404) Not Found") {
+  simpleError(paste0(
+    "Could not access the Google Drive resource:\n",
+    "  https://drive.google.com/file/d/1nXPS3bpFUESYieNfXO25OKlZJEgqtRnD\n",
+    "  (open it in a browser to confirm it exists and is shared 'Anyone with the link')\n",
+    "  ", status
+  ))
+}
+
+test_that(".isGoogleDriveAccessError recognizes access failures but not other errors", {
+  expect_true(LandR:::.isGoogleDriveAccessError(drive_error()))
+  expect_true(LandR:::.isGoogleDriveAccessError(simpleError("Client error: (404) Not Found")))
+  expect_true(LandR:::.isGoogleDriveAccessError(simpleError("HTTP 403 Forbidden")))
+  expect_true(LandR:::.isGoogleDriveAccessError(simpleError("Permission denied")))
+
+  ## must not swallow unrelated failures and mislabel them as an access problem
+  expect_false(LandR:::.isGoogleDriveAccessError(simpleError("cannot open connection")))
+  expect_false(LandR:::.isGoogleDriveAccessError(simpleError("subscript out of bounds")))
+  expect_false(LandR:::.isGoogleDriveAccessError(simpleError("non-numeric argument")))
+})
+
+test_that(".withSCANFIAccess explains an access failure and keeps the original error", {
+  err <- tryCatch(
+    LandR:::.withSCANFIAccess(
+      stop(drive_error()),
+      what = "the SCANFI stand age map",
+      dataYear = 2020,
+      dataVersion = "V2",
+      urlArg = "ageURL",
+      alternatives = c("KNN", "NTEMS")
+    ),
+    error = function(e) conditionMessage(e)
+  )
+
+  ## the guidance is wrapped for the console, so match on content not layout
+  flat <- gsub("[[:space:]]+", " ", err)
+
+  expect_match(flat, "Could not download the SCANFI stand age map (V2 2020)", fixed = TRUE)
+  expect_match(flat, "permissions problem rather than a broken link", fixed = TRUE)
+
+  ## the three ways out
+  expect_match(flat, "https://opendata.nfis.org/", fixed = TRUE)
+  expect_match(flat, "googledrive::drive_auth()", fixed = TRUE)
+  expect_match(flat, "`ageURL`", fixed = TRUE)
+  expect_match(flat, 'dataSource = "KNN" or dataSource = "NTEMS"', fixed = TRUE)
+
+  ## the underlying error is still reported, not swallowed
+  expect_match(flat, "Client error: (404) Not Found", fixed = TRUE)
+})
+
+test_that(".withSCANFIAccess omits the bullets that do not apply", {
+  err <- tryCatch(
+    LandR:::.withSCANFIAccess(stop(drive_error()), what = "the SCANFI species layers"),
+    error = function(e) conditionMessage(e)
+  )
+
+  expect_match(err, "https://opendata.nfis.org/", fixed = TRUE)
+  expect_false(grepl("dataSource =", err, fixed = TRUE))
+  expect_false(grepl("pass it via", err, fixed = TRUE))
+})
+
+test_that(".withSCANFIAccess leaves unrelated errors alone", {
+  expect_error(
+    LandR:::.withSCANFIAccess(stop("something else broke"), what = "the SCANFI stand age map"),
+    "something else broke"
+  )
+  ## and does not add SCANFI guidance to them
+  err <- tryCatch(
+    LandR:::.withSCANFIAccess(stop("something else broke"), what = "the SCANFI stand age map"),
+    error = function(e) conditionMessage(e)
+  )
+  expect_false(grepl("opendata.nfis.org", err, fixed = TRUE))
+})
+
+test_that(".withSCANFIAccess is transparent when it succeeds or is disabled", {
+  expect_identical(LandR:::.withSCANFIAccess(42L, what = "x"), 42L)
+
+  ## `enabled = FALSE` must not intercept: used by functions serving several sources
+  expect_error(
+    LandR:::.withSCANFIAccess(stop(drive_error()), what = "x", enabled = FALSE),
+    "Could not access the Google Drive resource"
+  )
+  expect_identical(LandR:::.withSCANFIAccess(7L, what = "x", enabled = FALSE), 7L)
+})


### PR DESCRIPTION
Closes #163.

SCANFI is distributed through a Google Drive folder shared with collaborators rather than published openly. A user without access saw only `reproducible`'s generic failure:

```
Could not access the Google Drive resource:
  https://drive.google.com/file/d/1nXPS3bpFUESYieNfXO25OKlZJEgqtRnD
  (open it in a browser to confirm it exists and is shared 'Anyone with the link')
  Client error: (404) Not Found
```

That reads like a dead link, and sends people looking for a public mirror that doesn't exist. It's a permissions problem.

## What they see now

```
Could not download the SCANFI stand age map (V2 2020).

SCANFI is distributed through a restricted Google Drive folder, so this is
usually a permissions problem rather than a broken link: the Google account
you are authenticated as may not have been granted access.

To resolve it:
  * request access to the SCANFI data from the SCANFI team (see
    https://opendata.nfis.org/), then re-authenticate with
    googledrive::drive_auth()
  * or, if you already have the data, pass it via `ageURL`
  * or use a different data source: dataSource = "KNN" or dataSource =
    "NTEMS"

Original error:
  Could not access the Google Drive resource:
    ...
```

The bullets adapt: functions with no `dataSource` alternative or no URL argument omit those lines.

## Design

`.withSCANFIAccess()` (new, internal, `R/scanfi-access.R`) wraps a SCANFI download. Two things it deliberately does **not** do:

- **Swallow the original error** — it's quoted in full underneath, so nothing is lost for debugging.
- **Relabel unrelated failures** — anything that isn't an access failure is re-thrown untouched. `.isGoogleDriveAccessError()` matches Drive wording and 401/403/404-shaped messages, and is only ever applied to a known Drive fetch. Tested against `cannot open connection`, `subscript out of bounds`, etc.

An `enabled` flag lets functions serving several data sources wrap in place rather than duplicating the call across SCANFI and non-SCANFI branches.

## Wrapped

| function | site |
|---|---|
| `prepInputsStandAgeMap()` | V1 and V2 fetches |
| `prepRawBiomassMap()` | only when `dataSource == "SCANFI"` |
| `loadSCANFISpeciesLayers()` | folder listing + per-layer downloads |
| `convert_SCANFI_LCC_codes()` | LCC fetch |
| `prepInputs_SCANFI_LCC_FAO()` | SCANFI LCC fetch (not the public NFIS FAO layer) |

`prepSpeciesLayers_SCANFI()` and `speciesPresentFromSCANFI()` funnel through `loadSCANFISpeciesLayers()`, so they're covered.

## Verification

Exercised end-to-end against the genuinely inaccessible folder — the message above is the real output, not a mock. The pre-existing `test-prepRawBiomassMap.R` failure now reports `Could not download the SCANFI biomass map (V2 2000)` instead of a bare 404, which is the issue's scenario reproducing in our own suite.

Full suite: 65 tests, 0 failures (that one Drive error remains, environmental). 22 new expectations in `test-scanfi-access.R` covering detection, message content, pass-through of unrelated errors, and the `enabled = FALSE` path. Spell check clean.