### PR TITLE
fix(prepSpeciesLayers_SCANFI): Drive fallback used unbound year

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ URL:
     https://landr.predictiveecology.org,
     https://github.com/PredictiveEcology/LandR
 Date: 2026-08-23
-Version: 1.2.0.9009
+Version: 1.2.0.9010
 Authors@R: c(
     person("Eliot J B", "McIntire", email = "eliot.mcintire@nrcan-rncan.gc.ca",
            role = c("aut", "cre"), comment = c(ORCID = "0000-0002-6914-8316")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -153,6 +153,11 @@
 
 ## Bug fixes
 
+* `prepSpeciesLayers_SCANFI()`: the Google Drive fallback (taken when `RCurl::url.exists()`
+  fails, e.g. during a network blip) referenced `year`, which is not a formal, so it
+  resolved to `data.table::year` and failed with "cannot coerce type 'closure' to
+  vector of type 'character'". It now uses `dataYear`.
+
 * `assertERGs()` now gives an informative error when `ecoregionMap` carries no
   `ecoregionGroup` values (e.g. a GeoTIFF read without its companion `.aux.xml`,
   so the raster attribute table is missing), instead of a cryptic

--- a/R/prepSpeciesLayers.R
+++ b/R/prepSpeciesLayers.R
@@ -610,7 +610,7 @@ prepSpeciesLayers_SCANFI <- function(
   if (!RCurl::url.exists(url)) {
     ## ping website and use gdrive if not available
     if (requireNamespace("googledrive", quietly = TRUE)) {
-      driveFolder <- paste0("SCANFIForestAttributes_", year)
+      driveFolder <- paste0("SCANFIForestAttributes_", dataYear)
       shared_drive_url <- "https://drive.google.com/drive/folders/1zLYV-wcDjJfSflH1VkXG6sosqZZF4SYc"
 
       driveDT <- as.data.table(googledrive::drive_ls(googledrive::as_id(shared_drive_url)))

--- a/tests/testthat/test-prepSpeciesLayers-globals.R
+++ b/tests/testthat/test-prepSpeciesLayers-globals.R
@@ -1,0 +1,11 @@
+## `year` is not a formal of prepSpeciesLayers_SCANFI(); its Google Drive fallback
+## (taken when RCurl::url.exists() fails, e.g. during a network blip) referenced it
+## anyway, so it resolved to data.table::year and the call died with
+## "cannot coerce type 'closure' to vector of type 'character'".
+
+test_that("prepSpeciesLayers_SCANFI does not reference an unbound `year`", {
+  skip_if_not_installed("codetools")
+  vars <- codetools::findGlobals(prepSpeciesLayers_SCANFI, merge = FALSE)$variables
+  expect_false("year" %in% vars)
+  expect_true("dataYear" %in% names(formals(prepSpeciesLayers_SCANFI)))
+})


### PR DESCRIPTION
## Problem

`prepSpeciesLayers_SCANFI()` takes `dataYear`, but its Google Drive fallback branch, taken when `RCurl::url.exists()` fails, built the folder name with `year`:

```r
driveFolder <- paste0("SCANFIForestAttributes_", year)
```

`year` is not bound in the function, so it resolves to `data.table::year` and the call dies with `cannot coerce type closure to vector of type character`. It only shows up when the primary URL check fails, which is why it survived: FireSense ELF fit 15.1 hit it on 2026-09-07 after 1.9 h, during a GitHub/network outage.

## Fix

Use `dataYear`. Regression test in `tests/testthat/test-prepSpeciesLayers-globals.R`: `codetools::findGlobals()` on the function must not report `year` as a free variable (it does on `development`).

Companion module change: `PredictiveEcology/Biomass_speciesData` passes only `year =` (read from `...` by `prepSpeciesLayers_KNN()`), so `dataYear` never reached SCANFI/NTEMS; a PR adds `dataYear = P(sim)$dataYear`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3