### PR TITLE
fix: makePickellStack must not leave terra/raster memory ceilings changed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # LandR (development version)
 
+* `makePickellStack()` no longer leaves `terra::terraOptions(memmax)` and
+  `raster::rasterOptions(maxmemory)` changed after it returns. Both are global,
+  process-wide settings, so a caller that had set its own memory ceiling silently
+  kept LandR's for the rest of the session -- visible in a long-lived worker that
+  set `memmax = 4` and later found it at 1.
+
 ## Breaking changes
 
 * drop support for R 4.2 due to changes in dependency packages;

--- a/R/prepSpeciesLayers.R
+++ b/R/prepSpeciesLayers.R
@@ -885,6 +885,19 @@ makePickellStack <- function(PickellRaster, sppEquiv, sppEquivCol, destinationPa
   spRas <- PickellRaster
   spRas[] <- NA_integer_
 
+  ## Both of these are global, process-wide settings, so they must not outlive this
+  ## function: a caller that deliberately set its own memory ceiling would silently
+  ## keep ours for the rest of the session. Observed in a long-lived worker that had
+  ## set memmax = 4 and found it at 1 afterwards.
+  origTerraMemmax <- terra::terraOptions(print = FALSE)$memmax
+  on.exit(try(terra::terraOptions(memmax = origTerraMemmax), silent = TRUE), add = TRUE)
+  if (requireNamespace("raster", quietly = TRUE)) {
+    ## capture.output: rasterOptions() prints as a side effect when read
+    invisible(utils::capture.output(
+      origRasterMaxmemory <- raster::rasterOptions(default = FALSE)$maxmemory))
+    on.exit(try(raster::rasterOptions(maxmemory = origRasterMaxmemory), silent = TRUE), add = TRUE)
+  }
+
   rasterOptions(maxmemory = 1e9)
   terraOptions(memmax = 1L)
 

--- a/tests/testthat/test-terraOptionsRestore.R
+++ b/tests/testthat/test-terraOptionsRestore.R
@@ -1,0 +1,32 @@
+## `terraOptions()` and `rasterOptions()` are process-wide. A function that sets one
+## and returns without restoring it silently reconfigures the rest of the session --
+## which is what happened to a long-lived worker that had set memmax = 4 and later
+## found it at 1, set by makePickellStack().
+##
+## A behavioural test would need a Pickell raster fixture, so this asserts the
+## invariant at the source level: every function in this package that *sets* a terra
+## or raster option also registers a restore.
+
+test_that("functions that set terra/raster options restore them on exit", {
+  rdir <- testthat::test_path("..", "..", "R")
+  skip_if_not(dir.exists(rdir), "source not available (installed package)")
+
+  files <- list.files(rdir, pattern = "[.]R$", full.names = TRUE)
+  offenders <- character()
+
+  for (f in files) {
+    src <- readLines(f, warn = FALSE)
+    code <- grep("^\\s*#", src, invert = TRUE, value = TRUE)
+    ## a *setting* call passes a named argument; reading passes none, or print/default
+    sets <- grep("(terraOptions|rasterOptions)\\s*\\([^)]*=", code, value = TRUE)
+    sets <- grep("print\\s*=|default\\s*=", sets, invert = TRUE, value = TRUE)
+    if (!length(sets)) next
+    ## and the same file must register a restore
+    restores <- grep("on\\.exit\\(.*(terraOptions|rasterOptions)", code, value = TRUE)
+    if (!length(restores)) offenders <- c(offenders, basename(f))
+  }
+
+  expect_equal(offenders, character(0),
+               info = paste("these set a terra/raster option with no on.exit restore:",
+                            paste(offenders, collapse = ", ")))
+})


### PR DESCRIPTION
## The problem

`terraOptions()` and `rasterOptions()` are process-wide. `makePickellStack()` sets two memory ceilings and returns without restoring them:

```r
rasterOptions(maxmemory = 1e9)
terraOptions(memmax = 1L)
```

So any caller that had deliberately set its own ceiling silently inherits LandR's for the rest of the session. That is how it surfaced: a long-lived worker process had set `terraOptions(memmax = 4, todisk = TRUE)` at startup, ran many jobs in sequence, and was later found running with `memmax = 1`. In a worker loop that sources its configuration once and then runs job after job in the same R session, a leak like this outlives the job that caused it.

## The change

Capture both values before setting them and restore them with `on.exit(..., add = TRUE)`. `rasterOptions()` prints as a side effect when read, so the read is wrapped in `capture.output()`, mirroring how `reproducible` reads terra options. The `raster` read is guarded by `requireNamespace()`, since the restore should not be the thing that makes `raster` a hard dependency.

Behaviour inside the function is unchanged: the ceilings still apply for its duration, which is what they were there for.

## Test

`tests/testthat/test-terraOptionsRestore.R` asserts the invariant at source level: any file that *sets* a terra or raster option must also register an `on.exit` restore. A behavioural test would need a Pickell raster fixture; this catches the pattern regressing anywhere in the package, which is the failure mode that bit us.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3