### PR TITLE
fix: drop overwrite = TRUE from prepInputs calls

### DIFF
--- a/R/prepSpeciesLayers.R
+++ b/R/prepSpeciesLayers.R
@@ -372,7 +372,6 @@ prepSpeciesLayers_CASFRI <- function(
     method = "bilinear", ## ignore warning re: ngb (#5)
     datatype = "INT4U",
     writeTo = NULL,
-    overwrite = TRUE,
     userTags = c("CASFRIRas", "stable")
   )
 
@@ -432,7 +431,6 @@ prepSpeciesLayers_Pickell <- function(
     method = "bilinear", ## ignore warning re: ngb (#5)
     datatype = "INT2U",
     writeTo = NULL,
-    overwrite = TRUE,
     userTags = c("speciesLayers", "KNN", "Pickell", "stable")
   )
 

--- a/R/studyArea.R
+++ b/R/studyArea.R
@@ -59,8 +59,7 @@ studyAreaEco <- function(studyArea = NULL, destinationPath = tempdir(),
     url = url,
     destinationPath = destinationPath,
     projectTo = studyArea,
-    fun = "sf::st_read",
-    overwrite = TRUE
+    fun = "sf::st_read"
   )
 
   if (!is.null(studyArea)) {


### PR DESCRIPTION
These were workarounds for PredictiveEcology/reproducible#593, where `destinationPathShared` failed to link anything extracted from an archive. With the default `overwrite = FALSE` the second study area to want such an input got an **error**; `overwrite = TRUE` hid that, at the cost of re-downloading and re-extracting a private copy per caller. PredictiveEcology/reproducible#594 fixed the cause, so the workaround can go.

It was never harmless. These are fixed remote artefacts, so `overwrite = TRUE` meant every study area re-fetched and re-wrote its own copy. Measured on a 70-study-area run before the fix: **588 GB** of duplicates across 148 files, growing about 10 GB/hour.

Untouched: every `overwrite = TRUE` belonging to `writeRaster()`, `postProcessTo()`, `writeOutputs()` or `terra::ifel()`, where overwriting the output being produced is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T5BZwHeHMMhjzRK8eGCTp3